### PR TITLE
fix: support missing s/S timestamp styles

### DIFF
--- a/packages/fluxer_markdown/lib/src/renderers/fluxer_markdown_renderers.dart
+++ b/packages/fluxer_markdown/lib/src/renderers/fluxer_markdown_renderers.dart
@@ -1158,6 +1158,8 @@ class FluxerTimestampWidget extends StatelessWidget {
     final dt = DateTime.fromMillisecondsSinceEpoch(unix * 1000);
     final flag = element.attributes['flag'] ?? 'f';
     final text = switch (flag) {
+      's' => DateFormat.yMd().add_Hm().format(dt),
+      'S' => DateFormat.yMd().add_Hms().format(dt),
       't' => DateFormat.Hm().format(dt),
       'T' => DateFormat.Hms().format(dt),
       'd' => DateFormat.yMd().format(dt),

--- a/packages/fluxer_markdown/lib/src/syntaxes/fluxer_markdown_syntaxes.dart
+++ b/packages/fluxer_markdown/lib/src/syntaxes/fluxer_markdown_syntaxes.dart
@@ -213,7 +213,7 @@ class FluxerRoleMentionSyntax extends md.InlineSyntax {
 }
 
 class FluxerTimestampSyntax extends md.InlineSyntax {
-  FluxerTimestampSyntax() : super(r'<t:(\d+)(?::([tTdDfFR]))?>');
+  FluxerTimestampSyntax() : super(r'<t:(\d+)(?::([sStTdDfFR]))?>');
 
   static const tag = 'timestamp';
 

--- a/packages/fluxer_markdown/test/timestamp_syntax_test.dart
+++ b/packages/fluxer_markdown/test/timestamp_syntax_test.dart
@@ -48,6 +48,16 @@ void main() {
       expect(timestamps.single.attributes['flag'], 'R');
     });
 
+    test('accepts s and S timestamp styles', () {
+      final nodes = _inlineDocument().parseInline(
+        '<t:1618936830:s> <t:1618936830:S>',
+      );
+      final timestamps = _timestampNodes(nodes);
+      expect(timestamps, hasLength(2));
+      expect(timestamps[0].attributes['flag'], 's');
+      expect(timestamps[1].attributes['flag'], 'S');
+    });
+
     test('defaults the flag to f when the style is omitted', () {
       final nodes = _inlineDocument().parseInline('<t:1618936830>');
       final timestamps = _timestampNodes(nodes);


### PR DESCRIPTION
# What this PR solves/adds

- Resolves #147

## Requirements

- Link an issue (`Fixes #…`) or paste a [GitHub Discussion](https://github.com/orgs/fluxerapp/discussions) URL in this PR body.
- All commits must be signed and verified on GitHub (GPG, SSH, or S/MIME).
- Maintainers may add the `no-issue` label when traceability does not apply (e.g. docs only or release automation).

## PR type

- [ ] Feature
- [x] Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Feature requirements

Mobile:

<img width="404" height="268" alt="image" src="https://github.com/user-attachments/assets/3b7a5d3d-93ea-4b8c-9e06-03d02e9875fc" />

Desktop (different locale):

<img width="292" height="185" alt="image" src="https://github.com/user-attachments/assets/202620fd-df47-4219-aca0-20b75dc8cd0c" />

## Validation

- [x] I explained what this PR solves or adds.
- [x] I verified the changes locally.
- [x] I completed all required feature items, or marked them as `N/A` if not applicable.

## Release Notes

- Add support for missing s/S timestamp styles