### PR TITLE
ci(release-drafter-autolabel): allow action to run for forks

### DIFF
--- a/.github/workflows/release-drafter-autolabel.yml
+++ b/.github/workflows/release-drafter-autolabel.yml
@@ -1,7 +1,7 @@
 name: Release Drafter Autolabel
 
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - canary
       - beta


### PR DESCRIPTION
# What this PR solves/adds

Allows the action to run for forks. It does not have necessary access otherwise, so it will always fail. `pull_request_target` is safe here considered it's only labelling.

## Requirements

- Link an issue (`Fixes #…`) or paste a [GitHub Discussion](https://github.com/orgs/fluxerapp/discussions) URL in this PR body.
- All commits must be signed and verified on GitHub (GPG, SSH, or S/MIME).
- Maintainers may add the `no-issue` label when traceability does not apply (e.g. docs only or release automation).

## PR type

- [ ] Feature
- [ ] Fix
- [ ] Refactor
- [ ] Documentation
- [x] Other

## Feature requirements

If this PR is a feature, complete all items below.

- GitHub Discussion link: N/A
- Visual proof (screenshot or video): N/A

If this PR is not a feature, write `N/A` for both items.

## Validation

- [x] I explained what this PR solves or adds.
- [x] I verified the changes locally.
- [x] I completed all required feature items, or marked them as `N/A` if not applicable.

## Release Notes

- N/A
