### PR TITLE
fix: match timestamp markdown visuals with desktop

### DIFF
--- a/packages/fluxer_markdown/lib/src/renderers/fluxer_markdown_renderers.dart
+++ b/packages/fluxer_markdown/lib/src/renderers/fluxer_markdown_renderers.dart
@@ -560,12 +560,18 @@ class _MarkdownInlineRenderer {
       case FluxerEveryoneMentionSyntax.tag:
         return _buildEveryoneMention(node, effectiveStyle);
       case FluxerTimestampSyntax.tag:
-        return WidgetSpan(
-          alignment: PlaceholderAlignment.baseline,
-          baseline: TextBaseline.alphabetic,
-          child: FluxerTimestampWidget(
-            element: node,
-            baseStyle: effectiveStyle,
+        final timestampText = _formatTimestampText(node);
+        if (timestampText == null) {
+          return const TextSpan(text: '');
+        }
+        return TextSpan(
+          text: timestampText,
+          style: effectiveStyle.copyWith(
+            background: Paint()
+              ..color =
+                  (effectiveStyle.color ??
+                          Theme.of(context).colorScheme.onSurface)
+                      .withValues(alpha: 0.08),
           ),
         );
       case FluxerSpoilerSyntax.tag:
@@ -1139,46 +1145,25 @@ class FluxerEmojiWidget extends StatelessWidget {
   }
 }
 
-class FluxerTimestampWidget extends StatelessWidget {
-  const FluxerTimestampWidget({
-    required this.element,
-    required this.baseStyle,
-    super.key,
-  });
-
-  final md.Element element;
-  final TextStyle baseStyle;
-
-  @override
-  Widget build(BuildContext context) {
-    final unix = int.tryParse(element.textContent);
-    if (unix == null) {
-      return const SizedBox.shrink();
-    }
-
-    final dt = DateTime.fromMillisecondsSinceEpoch(unix * 1000);
-    final flag = element.attributes['flag'] ?? 'f';
-    final text = switch (flag) {
-      's' => DateFormat.yMd().add_Hm().format(dt),
-      'S' => DateFormat.yMd().add_Hms().format(dt),
-      't' => DateFormat.Hm().format(dt),
-      'T' => DateFormat.Hms().format(dt),
-      'd' => DateFormat.yMd().format(dt),
-      'D' => DateFormat.yMMMMd().format(dt),
-      'F' => DateFormat.yMMMMEEEEd().add_Hm().format(dt),
-      'R' => _relative(dt),
-      _ => DateFormat.yMMMMd().add_Hm().format(dt),
-    };
-
-    return Container(
-      decoration: BoxDecoration(
-        color: Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.08),
-        borderRadius: BorderRadius.circular(3),
-      ),
-      padding: const EdgeInsets.symmetric(horizontal: 2),
-      child: Text(text, style: baseStyle),
-    );
+String? _formatTimestampText(md.Element element) {
+  final unix = int.tryParse(element.textContent);
+  if (unix == null) {
+    return null;
   }
+
+  final dt = DateTime.fromMillisecondsSinceEpoch(unix * 1000);
+  final flag = element.attributes['flag'] ?? 'f';
+  return switch (flag) {
+    's' => DateFormat.yMd().add_Hm().format(dt),
+    'S' => DateFormat.yMd().add_Hms().format(dt),
+    't' => DateFormat.Hm().format(dt),
+    'T' => DateFormat.Hms().format(dt),
+    'd' => DateFormat.yMd().format(dt),
+    'D' => DateFormat.yMMMMd().format(dt),
+    'F' => DateFormat.yMMMMEEEEd().add_Hm().format(dt),
+    'R' => _relative(dt),
+    _ => DateFormat.yMMMMd().add_Hm().format(dt),
+  };
 }
 
 String _relative(DateTime dt) {

--- a/packages/fluxer_markdown/lib/src/renderers/fluxer_markdown_renderers.dart
+++ b/packages/fluxer_markdown/lib/src/renderers/fluxer_markdown_renderers.dart
@@ -561,7 +561,8 @@ class _MarkdownInlineRenderer {
         return _buildEveryoneMention(node, effectiveStyle);
       case FluxerTimestampSyntax.tag:
         return WidgetSpan(
-          alignment: PlaceholderAlignment.middle,
+          alignment: PlaceholderAlignment.baseline,
+          baseline: TextBaseline.alphabetic,
           child: FluxerTimestampWidget(
             element: node,
             baseStyle: effectiveStyle,
@@ -1168,34 +1169,14 @@ class FluxerTimestampWidget extends StatelessWidget {
       'R' => _relative(dt),
       _ => DateFormat.yMMMMd().add_Hm().format(dt),
     };
-    final iconColor = Theme.of(context).colorScheme.onSurfaceVariant;
-    final fontSize = (baseStyle.fontSize ?? 16) * 0.85;
 
     return Container(
       decoration: BoxDecoration(
-        color: Theme.of(context).colorScheme.surfaceContainerHighest,
+        color: Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.08),
         borderRadius: BorderRadius.circular(3),
       ),
-      padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 1),
-      child: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Icon(
-            PhosphorIconsFill.clock,
-            size: fontSize,
-            color: iconColor.withValues(alpha: 0.7),
-          ),
-          const SizedBox(width: 3),
-          Text(
-            text,
-            style: baseStyle.copyWith(
-              fontSize: fontSize,
-              color: iconColor,
-              fontFamily: 'monospace',
-            ),
-          ),
-        ],
-      ),
+      padding: const EdgeInsets.symmetric(horizontal: 2),
+      child: Text(text, style: baseStyle),
     );
   }
 }

--- a/packages/fluxer_markdown/test/timestamp_syntax_test.dart
+++ b/packages/fluxer_markdown/test/timestamp_syntax_test.dart
@@ -106,7 +106,7 @@ void main() {
     });
   });
 
-  group('FluxerTimestampWidget rendering', () {
+  group('FluxerTimestamp rendering', () {
     final features = FluxerMarkdownFeatures.forContext(
       FluxerMarkdownContext.standardWithJumbo,
     );
@@ -138,15 +138,19 @@ void main() {
     ) async {
       await pumpMarkdown(tester, '<t:15778476000000000:f>');
       expect(tester.takeException(), isNull);
-      expect(find.byType(FluxerTimestampWidget), findsNothing);
     });
 
-    testWidgets('renders a valid timestamp as a FluxerTimestampWidget', (
+    testWidgets('renders a valid timestamp as inline formatted text', (
       tester,
     ) async {
       await pumpMarkdown(tester, '<t:1618936830:f>');
       expect(tester.takeException(), isNull);
-      expect(find.byType(FluxerTimestampWidget), findsOneWidget);
+      final List<String> renderedTexts = tester
+          .widgetList<RichText>(find.byType(RichText))
+          .map((RichText richText) => richText.text.toPlainText())
+          .toList();
+      expect(renderedTexts.any((String t) => t.contains('2021')), isTrue);
+      expect(renderedTexts.any((String t) => t.contains('<t:')), isFalse);
     });
   });
 }


### PR DESCRIPTION
# What this PR solves/adds

Matched timestamp markdown visuals as close as possible with Discord. Opted for a simple text span to allow wrapping onto new lines.

<details>
<summary>Mobile and desktop comparison</summary>

<img width="201" height="437" alt="image" src="https://github.com/user-attachments/assets/94d1f148-dd6b-4fde-960c-6b84b335af63" />

<img width="436" height="367" alt="image" src="https://github.com/user-attachments/assets/4e1c4257-7d46-4f2b-a598-d4aaffffe557" />

The ~1 month markdown difference between platforms is not related to this change.
</details>

Resolves #142.

## PR type

- [ ] Feature
- [x] Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Feature requirements

- GitHub Discussion link: N/A
- Visual proof (screenshot or video): N/A

## Validation

- [x] I explained what this PR solves or adds.
- [x] I verified the changes locally.
- [x] I completed all required feature items, or marked them as `N/A` if not applicable.

## Release Notes

- Matched timestamp markdown with desktop
