### PR TITLE
fix(fluxer_tag_change_sheet): set `_kMinUsernameLength` to 1

### DIFF
--- a/lib/features/settings/presentation/widgets/fluxer_tag_change_sheet.dart
+++ b/lib/features/settings/presentation/widgets/fluxer_tag_change_sheet.dart
@@ -16,7 +16,7 @@ import 'package:fluxer_dart/export.dart';
 import 'package:intl/intl.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
 
-const int _kMinUsernameLength = 2;
+const int _kMinUsernameLength = 1;
 const int _kMaxUsernameLength = 32;
 final RegExp _kUsernamePattern = RegExp(r'^[a-zA-Z0-9_]+$');
 


### PR DESCRIPTION
# What this PR solves/adds

Usernames are 1-32 characters. `_kMinUsernameLength` has been changed to `1` (was `2`). Resolves #317.

<details>
<summary>Evidence</summary>

<img width="201" height="437" alt="image" src="https://github.com/user-attachments/assets/0f56e07d-859a-4421-8f33-b2ce524c92e8" />

</details>

## PR type

- [ ] Feature
- [x] Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Feature requirements

- GitHub Discussion link: N/A
- Visual proof (screenshot or video): N/A

## Validation

- [x] I explained what this PR solves or adds.
- [x] I verified the changes locally.
- [x] I completed all required feature items, or marked them as `N/A` if not applicable.

## Release Notes

- Fixed username's minimum length check to 1 from 2
