### PR TITLE
fix: show uncategorised channels without a cosmetic parent

### DIFF
--- a/lib/features/channels/domain/channel.dart
+++ b/lib/features/channels/domain/channel.dart
@@ -133,16 +133,18 @@ class ChannelCategory {
     required this.name,
     required this.channels,
   });
+
+  bool get isUncategorized => id == kUncategorizedCategoryId;
 }
 
-/// Synthetic category id for channels that have no parent category.
+/// Internal group id for channels that have no parent category.
 const String kUncategorizedCategoryId = '_uncategorized';
 
 /// Groups a flat list of channels into channel categories.
 ///
 /// Channels with type 4 (category) become group headers. Child channels
 /// reference their category via parentId. Channels without a parent
-/// are placed in a synthetic "Channels" category.
+/// are placed in an internal uncategorized group.
 List<ChannelCategory> groupChannelsIntoCategories(List<Channel> channels) {
   final categories = <Channel>[];
   final uncategorized = <Channel>[];

--- a/lib/features/channels/presentation/widgets/guild_sidebar.dart
+++ b/lib/features/channels/presentation/widgets/guild_sidebar.dart
@@ -332,7 +332,6 @@ class _GuildSidebarState extends ConsumerState<GuildSidebar> {
   }) {
     final List<_GuildSidebarEntry> entries = <_GuildSidebarEntry>[];
     for (final ChannelCategory category in categories) {
-      final bool isSynthetic = category.id == kUncategorizedCategoryId;
       final bool isCollapsed = collapsed.contains(category.id);
       final bool isCategoryMuted = mutedSet.contains(category.id);
 
@@ -358,7 +357,7 @@ class _GuildSidebarState extends ConsumerState<GuildSidebar> {
         continue;
       }
 
-      if (!isSynthetic) {
+      if (!category.isUncategorized) {
         entries.add(
           _GuildSidebarEntry(
             kind: _GuildSidebarEntryKind.categoryHeader,
@@ -368,7 +367,7 @@ class _GuildSidebarState extends ConsumerState<GuildSidebar> {
         );
       }
 
-      if (!isSynthetic && isCollapsed) {
+      if (!category.isUncategorized && isCollapsed) {
         for (final Channel channel in base) {
           if (shouldShowChannelInCollapsedCategory(
             isCategoryMuted: isCategoryMuted,
@@ -989,16 +988,11 @@ class _CategoryHeader extends ConsumerWidget {
         .where(_canMarkChannelRead)
         .map((channel) => channel.id)
         .toList();
-    final bool isSynthetic = category.id == kUncategorizedCategoryId;
     final Set<String> mutedIds =
         ref.read(mutedChannelIdsProvider(guildId)).value ?? const <String>{};
     final bool isMuted = mutedIds.contains(category.id);
-    final muteConfig = isSynthetic
-        ? null
-        : await _loadChannelMuteConfig(ref, guildId, category.id);
-    final String? mutedHint = (!isSynthetic && isMuted)
-        ? formatMutedHintText(muteConfig)
-        : null;
+    final muteConfig = await _loadChannelMuteConfig(ref, guildId, category.id);
+    final String? mutedHint = isMuted ? formatMutedHintText(muteConfig) : null;
     if (!context.mounted) {
       return;
     }
@@ -1015,34 +1009,32 @@ class _CategoryHeader extends ConsumerWidget {
             unawaited(_readStateRepository(ref).ackLatestBulk(channelIds));
           },
         ),
-        if (!isSynthetic)
-          FluxerMenuItem(
-            label: isMuted ? 'Unmute Category' : 'Mute Category',
-            icon: isMuted
-                ? PhosphorIconsRegular.bell
-                : PhosphorIconsRegular.bellSlash,
-            hint: mutedHint,
-            onPressed: () {
-              unawaited(
-                _openCategoryMuteSheet(
-                  menuContext,
-                  ref,
-                  close: close,
-                  isMuted: isMuted,
-                  muteConfig: muteConfig,
-                ),
-              );
-            },
-          ),
-        if (!isSynthetic)
-          FluxerMenuItem(
-            label: 'Copy Category ID',
-            icon: PhosphorIconsRegular.copy,
-            onPressed: () {
-              close();
-              unawaited(_copyToClipboard(ref, category.id));
-            },
-          ),
+        FluxerMenuItem(
+          label: isMuted ? 'Unmute Category' : 'Mute Category',
+          icon: isMuted
+              ? PhosphorIconsRegular.bell
+              : PhosphorIconsRegular.bellSlash,
+          hint: mutedHint,
+          onPressed: () {
+            unawaited(
+              _openCategoryMuteSheet(
+                menuContext,
+                ref,
+                close: close,
+                isMuted: isMuted,
+                muteConfig: muteConfig,
+              ),
+            );
+          },
+        ),
+        FluxerMenuItem(
+          label: 'Copy Category ID',
+          icon: PhosphorIconsRegular.copy,
+          onPressed: () {
+            close();
+            unawaited(_copyToClipboard(ref, category.id));
+          },
+        ),
       ],
     );
   }

--- a/lib/features/channels/presentation/widgets/guild_sidebar.dart
+++ b/lib/features/channels/presentation/widgets/guild_sidebar.dart
@@ -332,6 +332,7 @@ class _GuildSidebarState extends ConsumerState<GuildSidebar> {
   }) {
     final List<_GuildSidebarEntry> entries = <_GuildSidebarEntry>[];
     for (final ChannelCategory category in categories) {
+      final bool isSynthetic = category.id == kUncategorizedCategoryId;
       final bool isCollapsed = collapsed.contains(category.id);
       final bool isCategoryMuted = mutedSet.contains(category.id);
 
@@ -357,15 +358,17 @@ class _GuildSidebarState extends ConsumerState<GuildSidebar> {
         continue;
       }
 
-      entries.add(
-        _GuildSidebarEntry(
-          kind: _GuildSidebarEntryKind.categoryHeader,
-          category: category,
-          isCategoryCollapsed: isCollapsed,
-        ),
-      );
+      if (!isSynthetic) {
+        entries.add(
+          _GuildSidebarEntry(
+            kind: _GuildSidebarEntryKind.categoryHeader,
+            category: category,
+            isCategoryCollapsed: isCollapsed,
+          ),
+        );
+      }
 
-      if (isCollapsed) {
+      if (!isSynthetic && isCollapsed) {
         for (final Channel channel in base) {
           if (shouldShowChannelInCollapsedCategory(
             isCategoryMuted: isCategoryMuted,

--- a/test/features/channels/presentation/widgets/guild_sidebar_test.dart
+++ b/test/features/channels/presentation/widgets/guild_sidebar_test.dart
@@ -131,6 +131,7 @@ void main() {
               ],
               selectedChannelId: null,
             ),
+            collapsed: const {kUncategorizedCategoryId},
             unread: const {'uncategorized': UnreadState()},
           ),
         ),

--- a/test/features/channels/presentation/widgets/guild_sidebar_test.dart
+++ b/test/features/channels/presentation/widgets/guild_sidebar_test.dart
@@ -106,6 +106,42 @@ void main() {
     });
   });
 
+  group('GuildSidebar channels without a category', () {
+    testWidgets('renders channels without a category with no header', (
+      tester,
+    ) async {
+      _setMobileSurface(tester);
+      await tester.pumpWidget(
+        _buildTestApp(
+          overrides: _buildOverrides(
+            channelListState: const ChannelListState(
+              guild: Guild(id: _guildId, name: 'Test Guild'),
+              categories: [
+                ChannelCategory(
+                  id: kUncategorizedCategoryId,
+                  name: 'Channels',
+                  channels: [
+                    Channel(
+                      id: 'uncategorized',
+                      guildId: _guildId,
+                      name: 'uncategorized',
+                    ),
+                  ],
+                ),
+              ],
+              selectedChannelId: null,
+            ),
+            unread: const {'uncategorized': UnreadState()},
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('uncategorized'), findsOneWidget);
+      expect(find.text('Channels'), findsNothing);
+    });
+  });
+
   group('GuildSidebar long-press menus', () {
     testWidgets('channel menu shows copy and notification actions', (
       tester,


### PR DESCRIPTION
# What this PR solves/adds

Resolves #144.

After conditionally adding categories, `isSynthetic` became always `false`, hence the cleanup.

<details><summary>Evidence</summary>

<img width="201" height="437" alt="image" src="https://github.com/user-attachments/assets/f070f09c-1235-4043-834e-47260c829328" />f

</details>

## PR type

- [ ] Feature
- [x] Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Feature requirements

- GitHub Discussion link: N/A
- Visual proof (screenshot or video): N/A

## Validation

- [x] I explained what this PR solves or adds.
- [x] I verified the changes locally.
- [x] I completed all required feature items, or marked them as `N/A` if not applicable.

## Release Notes

- Fixed uncategorised channels showing a parent category
