### PR TITLE
fix(fluxer_markdown_features): Hyperlink URLs in embeds

### DIFF
--- a/packages/fluxer_markdown/lib/src/contexts/fluxer_markdown_features.dart
+++ b/packages/fluxer_markdown/lib/src/contexts/fluxer_markdown_features.dart
@@ -67,7 +67,7 @@ class FluxerMarkdownFeatures {
       ),
       FluxerMarkdownContext.restrictedEmbedDescription =>
         const FluxerMarkdownFeatures(
-          allowAutolinks: false,
+          allowAutolinks: true,
           allowAlerts: false,
           allowBlockquotes: true,
           allowChannelMentions: true,

--- a/packages/fluxer_markdown/lib/src/contexts/fluxer_markdown_features.dart
+++ b/packages/fluxer_markdown/lib/src/contexts/fluxer_markdown_features.dart
@@ -2,7 +2,6 @@ import 'package:fluxer_markdown/src/contexts/fluxer_markdown_context.dart';
 
 class FluxerMarkdownFeatures {
   const FluxerMarkdownFeatures({
-    required this.allowAutolinks,
     required this.allowAlerts,
     required this.allowBlockquotes,
     required this.allowChannelMentions,
@@ -20,7 +19,6 @@ class FluxerMarkdownFeatures {
   factory FluxerMarkdownFeatures.forContext(FluxerMarkdownContext context) {
     return switch (context) {
       FluxerMarkdownContext.standardWithJumbo => const FluxerMarkdownFeatures(
-        allowAutolinks: true,
         allowAlerts: true,
         allowBlockquotes: true,
         allowChannelMentions: true,
@@ -36,7 +34,6 @@ class FluxerMarkdownFeatures {
       ),
       FluxerMarkdownContext.restrictedInlineReply =>
         const FluxerMarkdownFeatures(
-          allowAutolinks: true,
           allowAlerts: false,
           allowBlockquotes: false,
           allowChannelMentions: true,
@@ -51,7 +48,6 @@ class FluxerMarkdownFeatures {
           allowUserMentions: true,
         ),
       FluxerMarkdownContext.restrictedUserBio => const FluxerMarkdownFeatures(
-        allowAutolinks: true,
         allowAlerts: false,
         allowBlockquotes: true,
         allowChannelMentions: true,
@@ -67,7 +63,6 @@ class FluxerMarkdownFeatures {
       ),
       FluxerMarkdownContext.restrictedEmbedDescription =>
         const FluxerMarkdownFeatures(
-          allowAutolinks: true,
           allowAlerts: false,
           allowBlockquotes: true,
           allowChannelMentions: true,
@@ -83,7 +78,6 @@ class FluxerMarkdownFeatures {
         ),
       FluxerMarkdownContext.standardWithoutJumbo =>
         const FluxerMarkdownFeatures(
-          allowAutolinks: true,
           allowAlerts: true,
           allowBlockquotes: true,
           allowChannelMentions: true,
@@ -100,7 +94,6 @@ class FluxerMarkdownFeatures {
     };
   }
 
-  final bool allowAutolinks;
   final bool allowAlerts;
   final bool allowBlockquotes;
   final bool allowChannelMentions;
@@ -117,7 +110,6 @@ class FluxerMarkdownFeatures {
   @override
   bool operator ==(Object other) =>
       other is FluxerMarkdownFeatures &&
-      other.allowAutolinks == allowAutolinks &&
       other.allowAlerts == allowAlerts &&
       other.allowBlockquotes == allowBlockquotes &&
       other.allowChannelMentions == allowChannelMentions &&
@@ -133,7 +125,6 @@ class FluxerMarkdownFeatures {
 
   @override
   int get hashCode => Object.hash(
-    allowAutolinks,
     allowAlerts,
     allowBlockquotes,
     allowChannelMentions,

--- a/packages/fluxer_markdown/lib/src/utils/extension_set_factory.dart
+++ b/packages/fluxer_markdown/lib/src/utils/extension_set_factory.dart
@@ -12,7 +12,7 @@ md.ExtensionSet buildFluxerMarkdownExtensionSet(
   final inlineSyntaxes = <md.InlineSyntax>[
     md.InlineHtmlSyntax(),
     md.StrikethroughSyntax(),
-    if (features.allowAutolinks) md.AutolinkExtensionSyntax(),
+    md.AutolinkExtensionSyntax(),
   ];
 
   return md.ExtensionSet(

--- a/packages/fluxer_markdown/lib/src/widgets/fluxer_markdown.dart
+++ b/packages/fluxer_markdown/lib/src/widgets/fluxer_markdown.dart
@@ -242,7 +242,7 @@ class FluxerMarkdown extends StatelessWidget {
       FluxerCustomEmojiSyntax(),
       if (config.unicodeEmojiPattern != null)
         FluxerRawUnicodeEmojiSyntax(config.unicodeEmojiPattern!),
-      if (features.allowAutolinks) md.AutolinkExtensionSyntax(),
+      md.AutolinkExtensionSyntax(),
     ];
   }
 }

--- a/packages/fluxer_markdown/test/message_text_flow_test.dart
+++ b/packages/fluxer_markdown/test/message_text_flow_test.dart
@@ -141,6 +141,37 @@ void main() {
   });
 
   group('FluxerMarkdown widget', () {
+    testWidgets('restricted embed descriptions automatically link URLs', (
+      tester,
+    ) async {
+      const String url = 'https://example.com/image.png';
+      String? tappedHref;
+      final FluxerMarkdownConfig config = FluxerMarkdownConfig(
+        resolveEmojiShortcode: _noopEmojiShortcode,
+        unicodeEmojiUrlBuilder: _noopUnicodeEmojiUrl,
+        customEmojiUrlBuilder: _noopCustomEmojiUrl,
+        onTapLink: (_, href) async {
+          tappedHref = href;
+        },
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: FluxerMarkdown(
+              data: 'Mobile: $url',
+              config: config,
+              context: FluxerMarkdownContext.restrictedEmbedDescription,
+            ),
+          ),
+        ),
+      );
+
+      await tester.tapOnText(find.textRange.ofSubstring(url));
+
+      expect(tappedHref, url);
+    });
+
     testWidgets('uses configured blockquote divider and text colors', (
       tester,
     ) async {


### PR DESCRIPTION
# What this PR solves/adds

Embed descriptions and field values did not automatically hyperlink. Fixing this would warrant setting `allowAutolinks` to `true`, but this meant in all contexts, `allowAutolinks` would be `true`, so I opted to simply remove it.

Resolves #327.

<details><summary>Evidence</summary>

<img width="201" height="437" alt="image" src="https://github.com/user-attachments/assets/986dec4a-cf10-484a-a639-f383a5dda98e" />

</details> 

## PR type

- [ ] Feature
- [x] Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Feature requirements

- GitHub Discussion link: N/A
- Visual proof (screenshot or video): N/A

## Validation

- [x] I explained what this PR solves or adds.
- [x] I verified the changes locally.
- [x] I completed all required feature items, or marked them as `N/A` if not applicable.

## Release Notes

- Fixed bare URLs hyperlinking in embed description and field values
