### PR TITLE
fix(favorite_channel_groups_provider): reveal empty categories

### DIFF
--- a/lib/features/favorites/providers/favorite_channel_groups_provider.dart
+++ b/lib/features/favorites/providers/favorite_channel_groups_provider.dart
@@ -80,7 +80,11 @@ final Provider<List<FavoriteChannelGroup>> favoriteChannelGroupsProvider =
           ),
         );
       }
-      return groups.where((group) => group.entries.isNotEmpty).toList();
+      return groups
+          .where(
+            (group) => group.categoryId != null || group.entries.isNotEmpty,
+          )
+          .toList();
     });
 
 final Provider<String?> firstAccessibleFavoriteChannelIdProvider =


### PR DESCRIPTION
# What this PR solves/adds

Resolves #332. Newly-created categories have `group.categoryId != null` so they stay visible even when empty (which is the intended behaviour). Could not find an existing test for here, so left that alone.

<details><summary>Evidence</summary>

<img width="201" height="437" alt="image" src="https://github.com/user-attachments/assets/56b00cab-7fe2-46a1-9859-8925b2be9962" />

</details> 

## PR type

- [ ] Feature
- [x] Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Feature requirements

- GitHub Discussion link: N/A
- Visual proof (screenshot or video): N/A

## Validation

- [x] I explained what this PR solves or adds.
- [x] I verified the changes locally.
- [x] I completed all required feature items, or marked them as `N/A` if not applicable.

## Release Notes

- Revealed empty categories for favourites
