### PR TITLE
fix: match desktop community name abbreviations

### DIFF
--- a/lib/features/chat/presentation/widgets/embeds/embed_invite.dart
+++ b/lib/features/chat/presentation/widgets/embeds/embed_invite.dart
@@ -13,6 +13,7 @@ import 'package:fluxer_app/features/guilds/providers/guild_providers.dart';
 import 'package:fluxer_app/features/ui/badge/fluxer_guild_badge.dart';
 import 'package:fluxer_app/features/ui/button/fluxer_button.dart';
 import 'package:fluxer_app/l10n/generated/fluxer_localizations.dart';
+import 'package:fluxer_app/shared/utils/guild_name_abbreviation.dart';
 import 'package:fluxer_dart/export.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
 
@@ -315,7 +316,8 @@ class _GuildIcon extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final fallbackColor = context.colors.backgroundTertiary;
-    final initial = name.isNotEmpty ? name[0].toUpperCase() : '?';
+    final initials = abbreviateGuildName(name);
+    final initialsLength = guildNameInitialsLength(name);
 
     return Container(
       width: 44,
@@ -328,29 +330,41 @@ class _GuildIcon extends StatelessWidget {
               width: 44,
               height: 44,
               fit: BoxFit.cover,
-              errorBuilder: (_, _, _) => _Fallback(initial: initial),
+              errorBuilder: (_, _, _) =>
+                  _Fallback(initials: initials, initialsLength: initialsLength),
             )
-          : _Fallback(initial: initial),
+          : _Fallback(initials: initials, initialsLength: initialsLength),
     );
   }
 }
 
 class _Fallback extends StatelessWidget {
-  const _Fallback({required this.initial});
+  const _Fallback({required this.initials, required this.initialsLength});
 
-  final String initial;
+  final String initials;
+  final int initialsLength;
 
   @override
   Widget build(BuildContext context) => Center(
     child: Text(
-      initial,
+      initials,
       style: TextStyle(
         color: context.colors.textPrimary,
-        fontSize: 18,
+        fontSize: _guildInviteInitialsFontSize(initialsLength),
         fontWeight: FontWeight.w600,
       ),
     ),
   );
+}
+
+double _guildInviteInitialsFontSize(int initialsLength) {
+  if (initialsLength <= 2) {
+    return 18;
+  }
+  if (initialsLength <= kGuildIconInitialsMaxLength) {
+    return 15;
+  }
+  return 12;
 }
 
 class _StatDot extends StatelessWidget {

--- a/lib/features/chat/presentation/widgets/messages/forwarded_message_content.dart
+++ b/lib/features/chat/presentation/widgets/messages/forwarded_message_content.dart
@@ -21,6 +21,7 @@ import 'package:fluxer_app/features/chat/utils/channel_jump_navigator.dart';
 import 'package:fluxer_app/features/chat/utils/spoiler_utils.dart';
 import 'package:fluxer_app/features/guilds/domain/guild.dart';
 import 'package:fluxer_app/features/settings/providers/chat_preferences_provider.dart';
+import 'package:fluxer_app/shared/utils/guild_name_abbreviation.dart';
 import 'package:fluxer_markdown/fluxer_markdown.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
 
@@ -529,6 +530,8 @@ class _GuildSourceIcon extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     if (guild.iconUrl == null) {
+      final initials = abbreviateGuildName(guild.name);
+      final initialsLength = guildNameInitialsLength(guild.name);
       return Container(
         width: 16,
         height: 16,
@@ -538,9 +541,9 @@ class _GuildSourceIcon extends StatelessWidget {
         ),
         alignment: Alignment.center,
         child: Text(
-          guild.name.isNotEmpty ? guild.name[0].toUpperCase() : '?',
+          initials,
           style: TextStyle(
-            fontSize: 10,
+            fontSize: _forwardedGuildInitialsFontSize(initialsLength),
             fontWeight: FontWeight.w700,
             color: context.colors.textPrimary,
           ),
@@ -559,6 +562,16 @@ class _GuildSourceIcon extends StatelessWidget {
       ),
     );
   }
+}
+
+double _forwardedGuildInitialsFontSize(int initialsLength) {
+  if (initialsLength <= 2) {
+    return 10;
+  }
+  if (initialsLength <= kGuildIconInitialsMaxLength) {
+    return 8;
+  }
+  return 6.5;
 }
 
 enum _ForwardedSourceKind { guildChannel, dm, groupDm }

--- a/lib/features/chat/presentation/widgets/messages/message_mention.dart
+++ b/lib/features/chat/presentation/widgets/messages/message_mention.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:cached_network_image_ce/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/misc.dart' show FutureProviderFamily;
 import 'package:fluxer_app/core/providers/database_provider.dart';
 import 'package:fluxer_app/core/router/navigate_to_content.dart';
 import 'package:fluxer_app/core/router/route_names.dart';
@@ -17,8 +18,8 @@ import 'package:fluxer_app/features/guilds/providers/role_providers.dart';
 import 'package:fluxer_app/features/profile/presentation/user_profile_sheet.dart';
 import 'package:fluxer_app/l10n/generated/fluxer_localizations.dart';
 import 'package:fluxer_app/shared/providers/guild_user_display_provider.dart';
+import 'package:fluxer_app/shared/utils/guild_name_abbreviation.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
-import 'package:riverpod/src/providers/future_provider.dart';
 
 class ChannelMention extends ConsumerWidget {
   const ChannelMention({required this.channelId, this.baseStyle, super.key});
@@ -418,7 +419,8 @@ class _GuildInitials extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final initial = guild.name.isNotEmpty ? guild.name[0].toUpperCase() : '?';
+    final initials = abbreviateGuildName(guild.name);
+    final initialsLength = guildNameInitialsLength(guild.name);
     final colors = context.colors;
     return Container(
       width: size,
@@ -429,9 +431,9 @@ class _GuildInitials extends StatelessWidget {
       ),
       alignment: Alignment.center,
       child: Text(
-        initial,
+        initials,
         style: TextStyle(
-          fontSize: size * 0.6,
+          fontSize: _guildMentionInitialsFontSize(initialsLength, size),
           fontWeight: FontWeight.w700,
           color: colors.markupMentionText,
           height: 1,
@@ -439,4 +441,14 @@ class _GuildInitials extends StatelessWidget {
       ),
     );
   }
+}
+
+double _guildMentionInitialsFontSize(int initialsLength, double size) {
+  if (initialsLength <= 2) {
+    return size * 0.6;
+  }
+  if (initialsLength <= kGuildIconInitialsMaxLength) {
+    return size * 0.45;
+  }
+  return size * 0.35;
 }

--- a/lib/features/chat/presentation/widgets/plutonium_upsell_banner.dart
+++ b/lib/features/chat/presentation/widgets/plutonium_upsell_banner.dart
@@ -9,6 +9,7 @@ import 'package:fluxer_app/features/chat/providers/pickers/emoji_picker_provider
 import 'package:fluxer_app/features/guilds/domain/guild.dart';
 import 'package:fluxer_app/features/ui/plutonium_upsell/fluxer_plutonium_upsell.dart';
 import 'package:fluxer_app/l10n/generated/fluxer_localizations.dart';
+import 'package:fluxer_app/shared/utils/guild_name_abbreviation.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'plutonium_upsell_banner.g.dart';
@@ -166,19 +167,33 @@ class _GuildInitial extends StatelessWidget {
   final Guild guild;
 
   @override
-  Widget build(BuildContext context) => ColoredBox(
-    color: const Color.fromRGBO(255, 255, 255, 0.1),
-    child: Center(
-      child: Text(
-        guild.name.isNotEmpty ? guild.name[0].toUpperCase() : '?',
-        style: const TextStyle(
-          fontSize: 9,
-          fontWeight: FontWeight.w600,
-          color: Colors.white,
+  Widget build(BuildContext context) {
+    final initials = abbreviateGuildName(guild.name);
+    final initialsLength = guildNameInitialsLength(guild.name);
+    return ColoredBox(
+      color: const Color.fromRGBO(255, 255, 255, 0.1),
+      child: Center(
+        child: Text(
+          initials,
+          style: TextStyle(
+            fontSize: _plutoniumGuildInitialsFontSize(initialsLength),
+            fontWeight: FontWeight.w600,
+            color: Colors.white,
+          ),
         ),
       ),
-    ),
-  );
+    );
+  }
+}
+
+double _plutoniumGuildInitialsFontSize(int initialsLength) {
+  if (initialsLength <= 2) {
+    return 9;
+  }
+  if (initialsLength <= kGuildIconInitialsMaxLength) {
+    return 7.5;
+  }
+  return 6.5;
 }
 
 class _PreviewEmojiRow extends StatelessWidget {

--- a/lib/features/favorites/presentation/widgets/favorites_channel_list.dart
+++ b/lib/features/favorites/presentation/widgets/favorites_channel_list.dart
@@ -22,7 +22,6 @@ import 'package:fluxer_app/features/settings/providers/appearance_preferences_pr
 import 'package:fluxer_app/features/shell/presentation/responsive_layout.dart';
 import 'package:fluxer_app/features/ui/ui.dart';
 import 'package:fluxer_app/l10n/generated/fluxer_localizations.dart';
-import 'package:fluxer_app/shared/utils/guild_name_abbreviation.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
 
 class FavoritesChannelList extends ConsumerWidget {
@@ -490,7 +489,7 @@ class _FavoriteLeadingIcon extends ConsumerWidget {
           clipBehavior: Clip.none,
           children: [
             FluxerGuildIconAvatar(
-              abbreviation: abbreviateGuildName(guild.name),
+              name: guild.name,
               imageUrl: guild.iconUrl,
               isCircle: true,
               size: _avatarSize,

--- a/lib/features/guilds/presentation/widgets/guild_navbar.dart
+++ b/lib/features/guilds/presentation/widgets/guild_navbar.dart
@@ -1262,9 +1262,7 @@ class _GuildFolderWidgetState extends ConsumerState<_GuildFolderWidget>
                         color: context.colors.serverIconBackground,
                         child: Center(
                           child: Text(
-                            guild.name.isNotEmpty
-                                ? guild.name[0].toUpperCase()
-                                : '?',
+                            abbreviateGuildName(guild.name, maxLength: 2),
                             style: const TextStyle(
                               fontSize: 8,
                               fontWeight: FontWeight.w600,
@@ -2046,6 +2044,16 @@ class _InviteRecipient {
   final String? channelId;
 }
 
+double _guildNavbarInitialsFontSize(int initialsLength) {
+  if (initialsLength <= 2) {
+    return 20;
+  }
+  if (initialsLength <= kGuildIconInitialsMaxLength) {
+    return 16;
+  }
+  return 12;
+}
+
 class _GuildListItem extends StatefulWidget {
   final String label;
   final Guild? guild;
@@ -2217,6 +2225,8 @@ class _GuildListItemState extends State<_GuildListItem>
     final iconColor = isActive
         ? context.colors.textOnBrandPrimary
         : context.colors.textPrimary;
+    final initials = abbreviateGuildName(widget.label);
+    final initialsLength = guildNameInitialsLength(widget.label);
     return Center(
       child: widget.svgAsset != null
           ? SvgPicture.asset(
@@ -2228,11 +2238,12 @@ class _GuildListItemState extends State<_GuildListItem>
           : widget.icon != null
           ? PhosphorIcon(widget.icon!, color: iconColor, size: 32)
           : Text(
-              abbreviateGuildName(widget.label),
+              initials,
               style: TextStyle(
                 color: iconColor,
-                fontSize: 20,
+                fontSize: _guildNavbarInitialsFontSize(initialsLength),
                 fontWeight: FontWeight.w600,
+                height: 1,
               ),
             ),
     );

--- a/lib/features/notifications/data/mention_header_loader.dart
+++ b/lib/features/notifications/data/mention_header_loader.dart
@@ -3,10 +3,8 @@ import 'package:fluxer_app/features/channels/domain/channel.dart' as domain;
 import 'package:fluxer_app/features/chat/domain/message.dart';
 import 'package:fluxer_app/features/guilds/domain/guild.dart';
 import 'package:fluxer_app/features/notifications/domain/mention_header.dart';
-import 'package:fluxer_app/shared/utils/guild_name_abbreviation.dart';
 
 const String _kFallbackDmTitle = 'DM';
-const String _kFallbackDmAbbrev = 'DM';
 
 /// Whether [msg] points at a still-reachable channel: an existing DM, an
 /// existing guild channel without a guild row, or a guild channel whose guild
@@ -81,10 +79,7 @@ Future<MentionHeaderResult> _loadHeaderForChannelId(
   );
   if (dm == null) {
     return MentionHeaderResult(
-      header: MentionHeader.dm(
-        title: _kFallbackDmTitle,
-        abbrev: _kFallbackDmAbbrev,
-      ),
+      header: MentionHeader.dm(title: _kFallbackDmTitle),
       guildIdForPreview: '',
     );
   }
@@ -100,11 +95,11 @@ Future<MentionHeaderResult> _buildGuildHeader(
     mapped.guildId,
   );
   final bool isUnavailable = guild?.unavailable ?? false;
-  String abbrev = '?';
+  String iconName = '';
   String? iconUrl;
   if (guild != null) {
     final Guild mappedGuild = Guild.fromRow(guild);
-    abbrev = abbreviateGuildName(mappedGuild.name);
+    iconName = mappedGuild.name;
     if (!isUnavailable) {
       iconUrl =
           mappedGuild.hasAnimatedIcon && mappedGuild.animatedIconUrl != null
@@ -118,7 +113,7 @@ Future<MentionHeaderResult> _buildGuildHeader(
       primary: mapped.name,
       visual: mapped.type,
       secondaryLine: guildLine,
-      abbrev: abbrev,
+      iconName: iconName,
       isUnavailable: isUnavailable,
       iconUrl: iconUrl,
     ),
@@ -139,7 +134,7 @@ Future<MentionHeaderResult> _buildDmHeader(
     title = _kFallbackDmTitle;
   }
   return MentionHeaderResult(
-    header: MentionHeader.dm(title: title, abbrev: abbreviateGuildName(title)),
+    header: MentionHeader.dm(title: title),
     guildIdForPreview: '',
   );
 }

--- a/lib/features/notifications/data/unread_inbox_card_meta.dart
+++ b/lib/features/notifications/data/unread_inbox_card_meta.dart
@@ -2,10 +2,8 @@ import 'package:fluxer_app/core/database/fluxer_database.dart' as drift_db;
 import 'package:fluxer_app/features/channels/domain/channel.dart' as domain;
 import 'package:fluxer_app/features/guilds/domain/guild.dart';
 import 'package:fluxer_app/features/notifications/domain/unread_inbox_entry.dart';
-import 'package:fluxer_app/shared/utils/guild_name_abbreviation.dart';
 
 const String _kFallbackDmTitle = 'DM';
-const String _kFallbackAbbrev = '?';
 
 /// Snapshot of the metadata rendered in an unread-inbox card header: channel
 /// title, optional guild line, channel-type icon hint, and the rounded
@@ -17,7 +15,7 @@ class UnreadInboxCardMeta {
     required this.guildChannelVisualType,
     required this.guildIconDisplayUrl,
     required this.guildUnavailableForIcon,
-    required this.guildIconAbbrev,
+    required this.guildIconName,
   });
 
   factory UnreadInboxCardMeta.empty() => const UnreadInboxCardMeta(
@@ -26,7 +24,7 @@ class UnreadInboxCardMeta {
     guildChannelVisualType: domain.ChannelType.text,
     guildIconDisplayUrl: null,
     guildUnavailableForIcon: false,
-    guildIconAbbrev: _kFallbackAbbrev,
+    guildIconName: '',
   );
 
   final String channelTitle;
@@ -34,10 +32,10 @@ class UnreadInboxCardMeta {
   final domain.ChannelType guildChannelVisualType;
   final String? guildIconDisplayUrl;
   final bool guildUnavailableForIcon;
-  final String guildIconAbbrev;
+  final String guildIconName;
 }
 
-/// Resolves the display metadata (title, guild line, icon, abbreviation) for
+/// Resolves the display metadata (title, guild line, and icon inputs) for
 /// an [UnreadInboxEntry]. Always returns a usable snapshot — falls back to
 /// `'DM'` for unknown DM channels.
 Future<UnreadInboxCardMeta> loadUnreadInboxCardMeta(
@@ -71,7 +69,7 @@ Future<UnreadInboxCardMeta> _loadDmMeta(
     guildChannelVisualType: domain.ChannelType.text,
     guildIconDisplayUrl: null,
     guildUnavailableForIcon: false,
-    guildIconAbbrev: _kFallbackAbbrev,
+    guildIconName: '',
   );
 }
 
@@ -96,17 +94,17 @@ Future<UnreadInboxCardMeta> _loadGuildChannelMeta(
   final bool guildUnavailable = guild?.unavailable ?? false;
 
   String? iconUrl;
-  String abbrev = _kFallbackAbbrev;
+  String iconName = '';
   if (guild != null && !guildUnavailable) {
     final Guild mappedGuild = Guild.fromRow(guild);
-    abbrev = abbreviateGuildName(mappedGuild.name);
+    iconName = mappedGuild.name;
     iconUrl = mappedGuild.hasAnimatedIcon && mappedGuild.animatedIconUrl != null
         ? mappedGuild.animatedIconUrl
         : mappedGuild.iconUrl;
   } else if (guild != null) {
-    abbrev = abbreviateGuildName(guild.name);
+    iconName = guild.name;
   } else {
-    abbrev = abbreviateGuildName(channelName);
+    iconName = channelName;
   }
 
   return UnreadInboxCardMeta(
@@ -115,6 +113,6 @@ Future<UnreadInboxCardMeta> _loadGuildChannelMeta(
     guildChannelVisualType: visualType,
     guildIconDisplayUrl: guildUnavailable ? null : iconUrl,
     guildUnavailableForIcon: guildUnavailable,
-    guildIconAbbrev: abbrev,
+    guildIconName: iconName,
   );
 }

--- a/lib/features/notifications/domain/mention_header.dart
+++ b/lib/features/notifications/domain/mention_header.dart
@@ -10,18 +10,18 @@ class MentionHeader {
     required this.guildChannelVisualType,
     required this.isDm,
     required this.guildIconUrl,
-    required this.guildAbbrev,
+    required this.guildIconName,
     required this.isGuildUnavailable,
   });
 
-  factory MentionHeader.dm({required String title, required String abbrev}) {
+  factory MentionHeader.dm({required String title}) {
     return MentionHeader(
       primary: title,
       secondaryLine: '',
       guildChannelVisualType: ChannelType.text,
       isDm: true,
       guildIconUrl: null,
-      guildAbbrev: abbrev,
+      guildIconName: title,
       isGuildUnavailable: false,
     );
   }
@@ -30,7 +30,7 @@ class MentionHeader {
     required String primary,
     required ChannelType visual,
     required String secondaryLine,
-    required String abbrev,
+    required String iconName,
     required bool isUnavailable,
     String? iconUrl,
   }) {
@@ -40,7 +40,7 @@ class MentionHeader {
       guildChannelVisualType: visual,
       isDm: false,
       guildIconUrl: iconUrl,
-      guildAbbrev: abbrev,
+      guildIconName: iconName,
       isGuildUnavailable: isUnavailable,
     );
   }
@@ -50,7 +50,7 @@ class MentionHeader {
   final ChannelType guildChannelVisualType;
   final bool isDm;
   final String? guildIconUrl;
-  final String guildAbbrev;
+  final String guildIconName;
   final bool isGuildUnavailable;
 }
 

--- a/lib/features/notifications/presentation/widgets/mention_inbox_card.dart
+++ b/lib/features/notifications/presentation/widgets/mention_inbox_card.dart
@@ -81,7 +81,7 @@ class MentionInboxCard extends ConsumerWidget {
           )
         else
           FluxerGuildIconAvatar(
-            abbreviation: mentionHeader?.guildAbbrev ?? '?',
+            name: mentionHeader?.guildIconName ?? '',
             imageUrl: mentionHeader?.guildIconUrl,
             isUnavailable: mentionHeader?.isGuildUnavailable ?? false,
           ),

--- a/lib/features/notifications/presentation/widgets/unread_inbox_card_header.dart
+++ b/lib/features/notifications/presentation/widgets/unread_inbox_card_header.dart
@@ -90,7 +90,7 @@ class UnreadInboxCardHeader extends StatelessWidget {
         children: <Widget>[
           if (!entry.isDm) ...<Widget>[
             FluxerGuildIconAvatar(
-              abbreviation: meta.guildIconAbbrev,
+              name: meta.guildIconName,
               imageUrl: meta.guildIconDisplayUrl,
               isUnavailable: meta.guildUnavailableForIcon,
             ),

--- a/lib/features/profile/presentation/widgets/user_profile_bio_card.dart
+++ b/lib/features/profile/presentation/widgets/user_profile_bio_card.dart
@@ -34,23 +34,6 @@ class UserProfileBioCard extends StatelessWidget {
   final String? guildName;
   final String? guildIconUrl;
 
-  String _buildGuildAbbreviation() {
-    final String source = (guildName ?? '').trim();
-    if (source.isEmpty) {
-      return '?';
-    }
-    final List<String> parts = source
-        .split(RegExp(r'\s+'))
-        .where((String token) => token.isNotEmpty)
-        .toList(growable: false);
-    if (parts.length == 1) {
-      return parts.first.characters.first.toUpperCase();
-    }
-    final String first = parts.first.characters.first.toUpperCase();
-    final String second = parts[1].characters.first.toUpperCase();
-    return '$first$second';
-  }
-
   @override
   Widget build(BuildContext context) {
     final colors = context.colors;
@@ -147,7 +130,7 @@ class UserProfileBioCard extends StatelessWidget {
                       spacing: 4,
                       children: <Widget>[
                         FluxerGuildIconAvatar(
-                          abbreviation: _buildGuildAbbreviation(),
+                          name: guildName ?? '',
                           imageUrl: guildIconUrl,
                           isCircle: true,
                           size: 16,

--- a/lib/features/profile/presentation/widgets/user_profile_mutual_list.dart
+++ b/lib/features/profile/presentation/widgets/user_profile_mutual_list.dart
@@ -7,7 +7,6 @@ import 'package:fluxer_app/features/guilds/domain/guild.dart';
 import 'package:fluxer_app/features/profile/providers/user_profile_guild_provider.dart';
 import 'package:fluxer_app/features/ui/ui.dart';
 import 'package:fluxer_app/l10n/generated/fluxer_localizations.dart';
-import 'package:fluxer_app/shared/utils/guild_name_abbreviation.dart';
 import 'package:fluxer_dart/export.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
 
@@ -118,7 +117,7 @@ class _MutualCommunityList extends ConsumerWidget {
             final String? nick = community.nick?.trim();
             return FluxerListRow(
               leading: FluxerGuildIconAvatar(
-                abbreviation: abbreviateGuildName(title),
+                name: title,
                 imageUrl: server == null ? null : Guild.fromRow(server).iconUrl,
                 size: 40,
               ),

--- a/lib/features/quick_switcher/presentation/widgets/quick_switcher_result_row.dart
+++ b/lib/features/quick_switcher/presentation/widgets/quick_switcher_result_row.dart
@@ -7,7 +7,6 @@ import 'package:fluxer_app/features/dm/domain/dm_conversation.dart';
 import 'package:fluxer_app/features/quick_switcher/domain/quick_switcher_result_unread_state.dart';
 import 'package:fluxer_app/features/quick_switcher/domain/quick_switcher_types.dart';
 import 'package:fluxer_app/features/ui/ui.dart';
-import 'package:fluxer_app/shared/utils/guild_name_abbreviation.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
 
 // Web bottom sheet: 2rem slot, 24px avatars, ~1.75rem channel glyphs.
@@ -45,7 +44,9 @@ class QuickSwitcherResultRow extends StatelessWidget {
             children: <Widget>[
               _buildLeading(context, isHighlighted: isHighlighted),
               const SizedBox(width: 8),
-              Expanded(child: _buildText(context, isHighlighted: isHighlighted)),
+              Expanded(
+                child: _buildText(context, isHighlighted: isHighlighted),
+              ),
               if (unreadState.mentionCount > 0)
                 Padding(
                   padding: const EdgeInsets.only(left: 8),
@@ -120,7 +121,7 @@ class QuickSwitcherResultRow extends StatelessWidget {
             color: iconColor,
           ),
           QuickSwitcherGuildResult(:final guild) => FluxerGuildIconAvatar(
-            abbreviation: abbreviateGuildName(guild.name),
+            name: guild.name,
             imageUrl: guild.iconUrl,
             isCircle: true,
             size: _kAvatarRenderSize,
@@ -170,7 +171,9 @@ class QuickSwitcherResultRow extends StatelessWidget {
       QuickSwitcherLinkResult(:final subtitle) => subtitle,
       QuickSwitcherHeaderResult() => null,
     };
-    final Color titleColor = isHighlighted ? colors.textSecondary : colors.textPrimary;
+    final Color titleColor = isHighlighted
+        ? colors.textSecondary
+        : colors.textPrimary;
     final Color subtitleColor = isHighlighted
         ? colors.textSecondary.withValues(alpha: 0.8)
         : colors.textPrimaryMuted.withValues(alpha: 0.8);

--- a/lib/features/ui/avatar/fluxer_guild_icon_avatar.dart
+++ b/lib/features/ui/avatar/fluxer_guild_icon_avatar.dart
@@ -1,11 +1,13 @@
+import 'dart:math';
+
 import 'package:cached_network_image_ce/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:fluxer_app/core/theme/fluxer_theme_extension.dart';
+import 'package:fluxer_app/shared/utils/guild_name_abbreviation.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
 
 const double _kCornerRatio = 0.32;
 const double _kUnavailableIconSize = 22;
-const double _kFallbackFontSize = 13;
 
 /// Rounded-square server icon used by inbox-style notification cards.
 ///
@@ -15,7 +17,7 @@ const double _kFallbackFontSize = 13;
 /// - Letter-only fallback otherwise.
 class FluxerGuildIconAvatar extends StatelessWidget {
   const FluxerGuildIconAvatar({
-    required this.abbreviation,
+    required this.name,
     this.imageUrl,
     this.isUnavailable = false,
     this.isCircle = false,
@@ -23,7 +25,7 @@ class FluxerGuildIconAvatar extends StatelessWidget {
     super.key,
   });
 
-  final String abbreviation;
+  final String name;
   final String? imageUrl;
   final bool isUnavailable;
   final bool isCircle;
@@ -61,34 +63,50 @@ class FluxerGuildIconAvatar extends StatelessWidget {
     }
     final String? url = imageUrl;
     if (url == null) {
-      return _LetterFallback(text: abbreviation, color: colors.textPrimary);
+      return _LetterFallback(name: name, color: colors.textPrimary, size: size);
     }
     return CachedNetworkImage(
       imageUrl: url,
       fit: BoxFit.cover,
       errorBuilder: (BuildContext _, Object _, StackTrace? _) =>
-          _LetterFallback(text: abbreviation, color: colors.textPrimary),
+          _LetterFallback(name: name, color: colors.textPrimary, size: size),
     );
   }
 }
 
 class _LetterFallback extends StatelessWidget {
-  const _LetterFallback({required this.text, required this.color});
+  const _LetterFallback({
+    required this.name,
+    required this.color,
+    required this.size,
+  });
 
-  final String text;
+  final String name;
   final Color color;
+  final double size;
 
   @override
   Widget build(BuildContext context) {
     return Center(
       child: Text(
-        text,
+        abbreviateGuildName(name),
         style: TextStyle(
-          fontSize: _kFallbackFontSize,
+          fontSize: _guildInitialsFontSize(guildNameInitialsLength(name), size),
           fontWeight: FontWeight.w700,
           color: color,
+          height: 1,
         ),
       ),
     );
   }
+}
+
+double _guildInitialsFontSize(int length, double size) {
+  if (length <= 2) {
+    return min(13, size * 0.55);
+  }
+  if (length <= kGuildIconInitialsMaxLength) {
+    return min(11, size * 0.45);
+  }
+  return min(9, size * 0.35);
 }

--- a/lib/shared/utils/guild_name_abbreviation.dart
+++ b/lib/shared/utils/guild_name_abbreviation.dart
@@ -1,19 +1,33 @@
-/// Compact 1-2 character label for a guild/channel/user name.
-///
-/// Two-or-more-word names use the first letter of the first two words.
-/// Single-word names take up to the first two characters. Empty input
-/// resolves to `'?'`.
-String abbreviateGuildName(String raw) {
+const int kGuildIconInitialsMaxLength = 4;
+
+String guildNameInitials(String raw) {
   final String value = raw.trim();
   if (value.isEmpty) {
-    return '?';
+    return '';
   }
   final List<String> words = value
       .split(RegExp(r'\s+'))
       .where((String word) => word.isNotEmpty)
       .toList();
-  if (words.length >= 2) {
-    return '${words[0][0]}${words[1][0]}'.toUpperCase();
+  return words
+      .map((String word) => String.fromCharCode(word.runes.first))
+      .join();
+}
+
+/// Number of untruncated initials for a name.
+int guildNameInitialsLength(String raw) => guildNameInitials(raw).runes.length;
+
+/// Truncated variant. Empty input resolves to `'?'`.
+String abbreviateGuildName(
+  String raw, {
+  int maxLength = kGuildIconInitialsMaxLength,
+}) {
+  if (maxLength <= 0) {
+    return '';
   }
-  return value.substring(0, value.length.clamp(0, 2)).toUpperCase();
+  final String initials = guildNameInitials(raw);
+  if (initials.isEmpty) {
+    return '?';
+  }
+  return String.fromCharCodes(initials.runes.take(maxLength));
 }

--- a/test/shared/utils/guild_name_abbreviation_test.dart
+++ b/test/shared/utils/guild_name_abbreviation_test.dart
@@ -1,0 +1,32 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fluxer_app/shared/utils/guild_name_abbreviation.dart';
+
+void main() {
+  group('abbreviateGuildName', () {
+    const cases = <(String, int, String)>[
+      ('test one two three', 4, 'tott'),
+      ('Test One Two Three', 4, 'TOTT'),
+      ('Fluxer', 4, 'F'),
+      ('fluxer', 4, 'f'),
+      ('one two three four five', 4, 'ottf'),
+      ('one two three four five', 2, 'ot'),
+      ('   ', 4, '?'),
+      ('test one', 0, ''),
+      ('test-2🐛🐛🐛🐛🐛🐛🐛🐛🐛🐛🐛🐛v🐛', 4, 't'),
+      ('💖tes tes', 4, '💖t'),
+    ];
+
+    for (final (input, maxLength, expected) in cases) {
+      test('"$input" (max $maxLength) -> "$expected"', () {
+        expect(abbreviateGuildName(input, maxLength: maxLength), expected);
+      });
+    }
+  });
+
+  group('guildNameInitialsLength', () {
+    test('counts untruncated initials for font sizing', () {
+      expect(abbreviateGuildName('one two three four five'), 'ottf');
+      expect(guildNameInitialsLength('one two three four five'), 5);
+    });
+  });
+}


### PR DESCRIPTION
# What this PR solves/adds

Resolves #111. Implementation matches desktop + tested with emojis. Applied the fix everywhere possible rather than only in the sidebar.

Note: `''` is the default on desktop for a fallback, but `'?'` was retained here.

<details><summary>Evidence</summary>
<img width="201" height="473" alt="image" src="https://github.com/user-attachments/assets/9ef2a6df-76c0-4858-a326-c89a2b38f265" />

<img width="201" height="473" alt="image" src="https://github.com/user-attachments/assets/6bdccbd6-3b17-4e9f-9616-4d0ea5eaf90c" />

<img width="201" height="473" alt="image" src="https://github.com/user-attachments/assets/80172822-34ee-40b1-8c2c-7d787e6337b6" />

<img width="201" height="473" alt="image" src="https://github.com/user-attachments/assets/008d8dec-93aa-47a2-b43b-94ba574b1e49" />

</details> 

## PR type

- [ ] Feature
- [x] Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Feature requirements

- GitHub Discussion link: N/A
- Visual proof (screenshot or video): N/A

## Validation

- [x] I explained what this PR solves or adds.
- [x] I verified the changes locally.
- [x] I completed all required feature items, or marked them as `N/A` if not applicable.

## Release Notes

- Fixed community names without icons not matching desktop
