### PR TITLE
fix: do not use `cursor` for message searching

### DIFF
--- a/lib/features/chat/data/message_search_repository.dart
+++ b/lib/features/chat/data/message_search_repository.dart
@@ -36,7 +36,6 @@ class MessageSearchQuery {
     this.scope = MessageSearchScopeFilter.current,
     this.sort = MessageSearchSortFilter.newest,
     this.contentTypes = const <MessageSearchContentFilter>{},
-    this.cursor,
     this.page = 1,
   });
 
@@ -47,7 +46,6 @@ class MessageSearchQuery {
   final MessageSearchScopeFilter scope;
   final MessageSearchSortFilter sort;
   final Set<MessageSearchContentFilter> contentTypes;
-  final List<String>? cursor;
   final int page;
 
   MessageSearchQuery copyWith({
@@ -58,7 +56,6 @@ class MessageSearchQuery {
     MessageSearchScopeFilter? scope,
     MessageSearchSortFilter? sort,
     Set<MessageSearchContentFilter>? contentTypes,
-    Object? cursor = _unset,
     int? page,
   }) {
     return MessageSearchQuery(
@@ -69,7 +66,6 @@ class MessageSearchQuery {
       scope: scope ?? this.scope,
       sort: sort ?? this.sort,
       contentTypes: contentTypes ?? this.contentTypes,
-      cursor: cursor == _unset ? this.cursor : cursor as List<String>?,
       page: page ?? this.page,
     );
   }
@@ -99,7 +95,6 @@ class MessageSearchPage {
     required this.page,
     required this.hitsPerPage,
     required this.indexing,
-    this.cursor,
   });
 
   const MessageSearchPage.indexing()
@@ -107,22 +102,17 @@ class MessageSearchPage {
       total = 0,
       page = 1,
       hitsPerPage = kMessageSearchPageSize,
-      cursor = null,
       indexing = true;
 
   final List<MessageSearchResultEntry> results;
   final int total;
   final int page;
   final int hitsPerPage;
-  final List<String>? cursor;
   final bool indexing;
 
   bool get hasMore {
     if (indexing) {
       return false;
-    }
-    if (cursor != null && cursor!.isNotEmpty) {
-      return true;
     }
     return page * hitsPerPage < total;
   }
@@ -196,7 +186,6 @@ class MessageSearchRepository {
       total: results.total,
       page: results.page,
       hitsPerPage: results.hitsPerPage,
-      cursor: results.cursor,
       indexing: false,
     );
   }
@@ -228,8 +217,7 @@ GlobalSearchMessagesRequest buildGlobalSearchMessagesRequest(
 
   return GlobalSearchMessagesRequest(
     hitsPerPage: kMessageSearchPageSize,
-    page: query.cursor == null ? query.page : null,
-    cursor: query.cursor,
+    page: query.page,
     content: _blankToNull(query.text),
     authorId: authorIds,
     has: contentTypes.isEmpty ? null : contentTypes,

--- a/lib/features/chat/providers/channel/channel_details_providers.dart
+++ b/lib/features/chat/providers/channel/channel_details_providers.dart
@@ -259,7 +259,6 @@ class ChannelSearch extends _$ChannelSearch {
       scope: scope,
       sort: sort,
       contentTypes: contentTypes,
-      cursor: null,
       page: 1,
     );
     if (!nextQuery.hasSearchTerms) {
@@ -280,7 +279,7 @@ class ChannelSearch extends _$ChannelSearch {
           .read(messageSearchRepositoryProvider)
           .searchMessages(nextQuery);
       state = state.copyWith(
-        query: nextQuery.copyWith(cursor: page.cursor, page: page.page),
+        query: nextQuery,
         results: page.results,
         total: page.total,
         hasMore: page.hasMore,
@@ -301,18 +300,14 @@ class ChannelSearch extends _$ChannelSearch {
       return;
     }
     final currentQuery = state.query;
-    final nextQuery = currentQuery.copyWith(
-      page: currentQuery.cursor == null
-          ? currentQuery.page + 1
-          : currentQuery.page,
-    );
+    final nextQuery = currentQuery.copyWith(page: currentQuery.page + 1);
     state = state.copyWith(isLoadingMore: true);
     try {
       final page = await ref
           .read(messageSearchRepositoryProvider)
           .searchMessages(nextQuery);
       state = state.copyWith(
-        query: nextQuery.copyWith(cursor: page.cursor, page: page.page),
+        query: nextQuery,
         results: [...state.results, ...page.results],
         total: page.total,
         hasMore: page.hasMore,

--- a/test/features/chat/data/message_search_repository_test.dart
+++ b/test/features/chat/data/message_search_repository_test.dart
@@ -16,7 +16,6 @@ void main() {
 
       expect(request.hitsPerPage, kMessageSearchPageSize);
       expect(request.page, 1);
-      expect(request.cursor, isNull);
       expect(request.content, 'hello');
       expect(request.scope, MessageSearchScope.current);
       expect(request.contextChannelId, 'channel-1');
@@ -27,7 +26,7 @@ void main() {
       expect(request.has, isNull);
     });
 
-    test('maps cursor, author, content types, scope, and sort filters', () {
+    test('maps author, content types, scope, sort, and page filters', () {
       final request = buildGlobalSearchMessagesRequest(
         const MessageSearchQuery(
           channelId: 'channel-1',
@@ -39,13 +38,11 @@ void main() {
             MessageSearchContentFilter.image,
             MessageSearchContentFilter.audio,
           },
-          cursor: ['cursor-1'],
           page: 7,
         ),
       );
 
-      expect(request.page, isNull);
-      expect(request.cursor, ['cursor-1']);
+      expect(request.page, 7);
       expect(request.authorId, ['user-1', 'user-2']);
       expect(request.has, [MessageContentType.image, MessageContentType.sound]);
       expect(request.scope, MessageSearchScope.allGuilds);


### PR DESCRIPTION
# What this PR solves/adds

Desktop does not seem to use `cursor` for message searching, and simply not using `cursor` fixes the the pagination. Both desktop and mobile now pass `page` and the results seem identical.

Resolves #165.

## PR type

- [ ] Feature
- [x] Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Feature requirements

- GitHub Discussion link: N/A
- Visual proof (screenshot or video): N/A

## Validation

- [x] I explained what this PR solves or adds.
- [x] I verified the changes locally.
- [x] I completed all required feature items, or marked them as `N/A` if not applicable.

## Release Notes

- Fixes pagination in message search
