### PR TITLE
fix: system welcome message parity

### DIFF
--- a/lib/features/chat/presentation/widgets/messages/system_message.dart
+++ b/lib/features/chat/presentation/widgets/messages/system_message.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:fluxer_app/core/theme/fluxer_theme_extension.dart';
 import 'package:fluxer_app/features/chat/domain/message.dart';
+import 'package:fluxer_app/features/chat/utils/system_message_text.dart';
+import 'package:fluxer_app/l10n/generated/fluxer_localizations.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
 
 /// Renders a system message as a single row with an icon,
@@ -12,7 +14,20 @@ class SystemMessage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final (icon, text) = _iconAndText();
+    final textStyle = TextStyle(
+      color: context.colors.textTertiaryMuted,
+      fontSize: 14,
+    );
+    final usernameStyle = TextStyle(
+      color: context.colors.textChat,
+      fontWeight: FontWeight.bold,
+      fontSize: 14,
+    );
+    final (icon, textSpans) = _iconAndTextSpans(
+      context,
+      textStyle: textStyle,
+      usernameStyle: usernameStyle,
+    );
 
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
@@ -29,25 +44,7 @@ class SystemMessage extends StatelessWidget {
           const SizedBox(width: 8),
           Flexible(
             child: Text.rich(
-              TextSpan(
-                children: [
-                  TextSpan(
-                    text: message.authorName,
-                    style: TextStyle(
-                      color: context.colors.textChat,
-                      fontWeight: FontWeight.bold,
-                      fontSize: 14,
-                    ),
-                  ),
-                  TextSpan(
-                    text: ' $text',
-                    style: TextStyle(
-                      color: context.colors.textTertiaryMuted,
-                      fontSize: 14,
-                    ),
-                  ),
-                ],
-              ),
+              TextSpan(children: textSpans),
               overflow: TextOverflow.ellipsis,
             ),
           ),
@@ -64,19 +61,65 @@ class SystemMessage extends StatelessWidget {
     );
   }
 
+  (IconData, List<InlineSpan>) _iconAndTextSpans(
+    BuildContext context, {
+    required TextStyle textStyle,
+    required TextStyle usernameStyle,
+  }) {
+    if (message.type == messageTypeUserJoin) {
+      return (
+        PhosphorIconsFill.arrowRight,
+        _guildJoinTextSpans(
+          FluxerLocalizations.of(context),
+          textStyle: textStyle,
+          usernameStyle: usernameStyle,
+        ),
+      );
+    }
+
+    final (icon, text) = _iconAndText();
+    return (
+      icon,
+      <InlineSpan>[
+        TextSpan(text: message.authorName, style: usernameStyle),
+        TextSpan(text: ' $text', style: textStyle),
+      ],
+    );
+  }
+
+  List<InlineSpan> _guildJoinTextSpans(
+    FluxerLocalizations l10n, {
+    required TextStyle textStyle,
+    required TextStyle usernameStyle,
+  }) {
+    final template = resolveGuildJoinMessageTemplate(
+      l10n,
+      messageId: message.id,
+    );
+    final parts = template.split(kGuildJoinMessageUsernamePlaceholder);
+    if (parts.length == 1) {
+      return <InlineSpan>[TextSpan(text: template, style: textStyle)];
+    }
+    return <InlineSpan>[
+      for (var i = 0; i < parts.length; i++) ...[
+        if (parts[i].isNotEmpty) TextSpan(text: parts[i], style: textStyle),
+        if (i < parts.length - 1)
+          TextSpan(text: message.authorName, style: usernameStyle),
+      ],
+    ];
+  }
+
   (IconData, String) _iconAndText() {
     switch (message.type) {
-      case 7:
-        return (PhosphorIconsFill.arrowRight, 'joined the server.');
-      case 2:
+      case messageTypeRecipientRemove:
         return (PhosphorIconsFill.info, message.content);
-      case 3:
+      case messageTypeCall:
         return (PhosphorIconsFill.phone, 'started a call.');
-      case 4:
+      case messageTypeChannelNameChange:
         return (PhosphorIconsFill.textAa, 'changed the channel name.');
-      case 5:
+      case messageTypeChannelIconChange:
         return (PhosphorIconsFill.image, 'changed the channel icon.');
-      case 6:
+      case messageTypeChannelPinnedMessage:
         return (PhosphorIconsFill.pushPin, 'pinned a message.');
       default:
         return (PhosphorIconsFill.info, message.content);

--- a/lib/features/chat/presentation/widgets/messages/system_message.dart
+++ b/lib/features/chat/presentation/widgets/messages/system_message.dart
@@ -5,6 +5,8 @@ import 'package:fluxer_app/features/chat/utils/system_message_text.dart';
 import 'package:fluxer_app/l10n/generated/fluxer_localizations.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
 
+const Color _kGuildJoinIconColor = Color(0xFF22C55E);
+
 /// Renders a system message as a single row with an icon,
 /// bold author name, descriptive text, and timestamp.
 class SystemMessage extends StatelessWidget {
@@ -38,7 +40,9 @@ class SystemMessage extends StatelessWidget {
             child: PhosphorIcon(
               icon,
               size: 18,
-              color: context.colors.textTertiaryMuted,
+              color: message.type == messageTypeUserJoin
+                  ? _kGuildJoinIconColor
+                  : context.colors.textTertiaryMuted,
             ),
           ),
           const SizedBox(width: 8),
@@ -68,7 +72,7 @@ class SystemMessage extends StatelessWidget {
   }) {
     if (message.type == messageTypeUserJoin) {
       return (
-        PhosphorIconsFill.arrowRight,
+        PhosphorIconsBold.arrowRight,
         _guildJoinTextSpans(
           FluxerLocalizations.of(context),
           textStyle: textStyle,

--- a/lib/features/chat/utils/system_message_text.dart
+++ b/lib/features/chat/utils/system_message_text.dart
@@ -1,0 +1,68 @@
+import 'package:fluxer_app/l10n/generated/fluxer_localizations.dart';
+import 'package:fluxer_app/shared/utils/snowflake_time.dart';
+
+const String kGuildJoinMessageUsernamePlaceholder = '__USERNAME__';
+
+typedef GuildJoinMessageBuilder = String Function(String username);
+
+List<GuildJoinMessageBuilder> guildJoinMessageBuilders(
+  FluxerLocalizations l10n,
+) => <GuildJoinMessageBuilder>[
+  l10n.systemJoinGladYoureHere,
+  l10n.systemJoinWelcomeMakeYourselfAtHome,
+  l10n.systemJoinHelloNiceToHaveYouHere,
+  l10n.systemJoinHelloJumpInWheneverYoureReady,
+  l10n.systemJoinHeyGreatToSeeYouHere,
+  l10n.systemJoinHeyThereHopeYouEnjoyYourStay,
+  l10n.systemJoinHeyWelcomeAboard,
+  l10n.systemJoinGladYouMadeIt,
+  l10n.systemJoinWelcomeIn,
+  l10n.systemJoinWelcome,
+  l10n.systemJoinWelcomeWereGladYoureHere,
+  l10n.systemJoinWelcomeHopeYouEnjoyYourTimeHere,
+  l10n.systemJoinWelcomeYourNextConversationStartsHere,
+  l10n.systemJoinWelcomeWereHappyToHaveYouHere,
+  l10n.systemJoinGreatToSeeYouWelcomeIn,
+  l10n.systemJoinYoureHereGoodToHaveYouWithUs,
+  l10n.systemJoinYouveArrivedLetsGetStarted,
+];
+
+int guildJoinMessageIndex({
+  required String messageId,
+  required int messageCount,
+}) {
+  if (messageCount <= 0) {
+    return 0;
+  }
+  final int? parsed = int.tryParse(messageId);
+  if (parsed == null) {
+    return 0;
+  }
+  final int timestampMs = (parsed >> 22) + kSnowflakeEpochMs;
+  return timestampMs % messageCount;
+}
+
+String resolveGuildJoinMessageTemplate(
+  FluxerLocalizations l10n, {
+  required String messageId,
+}) {
+  final builders = guildJoinMessageBuilders(l10n);
+  final index = guildJoinMessageIndex(
+    messageId: messageId,
+    messageCount: builders.length,
+  );
+  return builders[index](kGuildJoinMessageUsernamePlaceholder);
+}
+
+String resolveGuildJoinMessage(
+  FluxerLocalizations l10n, {
+  required String messageId,
+  required String username,
+}) {
+  final builders = guildJoinMessageBuilders(l10n);
+  final index = guildJoinMessageIndex(
+    messageId: messageId,
+    messageCount: builders.length,
+  );
+  return builders[index](username);
+}

--- a/lib/l10n/fluxer_en.arb
+++ b/lib/l10n/fluxer_en.arb
@@ -3223,6 +3223,125 @@
   "@typingIndicatorApocalypse": {
     "description": "Typing indicator shown when 20 or more other users are typing."
   },
+  "systemJoinGladYoureHere": "Glad you're here, {username}!",
+  "@systemJoinGladYoureHere": {
+    "description": "Randomly selected welcome message that appears as a system message when a user joins a community. Plural placeholder is the new member username. Tone is friendly and warm; keep variety across these strings..",
+    "placeholders": {
+      "username": { "type": "String" }
+    }
+  },
+  "systemJoinWelcomeMakeYourselfAtHome": "Welcome, {username}! Make yourself at home.",
+  "@systemJoinWelcomeMakeYourselfAtHome": {
+    "description": "Randomly selected welcome message that appears as a system message when a user joins a community. Plural placeholder is the new member username. Tone is friendly and warm; keep variety across these strings..",
+    "placeholders": {
+      "username": { "type": "String" }
+    }
+  },
+  "systemJoinHelloNiceToHaveYouHere": "Hello, {username}! Nice to have you here.",
+  "@systemJoinHelloNiceToHaveYouHere": {
+    "description": "Randomly selected welcome message that appears as a system message when a user joins a community. Plural placeholder is the new member username. Tone is friendly and warm; keep variety across these strings..",
+    "placeholders": {
+      "username": { "type": "String" }
+    }
+  },
+  "systemJoinHelloJumpInWheneverYoureReady": "Hello, {username}! Jump in whenever you're ready.",
+  "@systemJoinHelloJumpInWheneverYoureReady": {
+    "description": "Randomly selected welcome message that appears as a system message when a user joins a community. Plural placeholder is the new member username. Tone is friendly and warm; keep variety across these strings..",
+    "placeholders": {
+      "username": { "type": "String" }
+    }
+  },
+  "systemJoinHeyGreatToSeeYouHere": "Hey {username}, great to see you here!",
+  "@systemJoinHeyGreatToSeeYouHere": {
+    "description": "Randomly selected welcome message that appears as a system message when a user joins a community. Plural placeholder is the new member username. Tone is friendly and warm; keep variety across these strings..",
+    "placeholders": {
+      "username": { "type": "String" }
+    }
+  },
+  "systemJoinHeyThereHopeYouEnjoyYourStay": "Hey there, {username}! Hope you enjoy your stay.",
+  "@systemJoinHeyThereHopeYouEnjoyYourStay": {
+    "description": "Randomly selected welcome message that appears as a system message when a user joins a community. Plural placeholder is the new member username. Tone is friendly and warm; keep variety across these strings..",
+    "placeholders": {
+      "username": { "type": "String" }
+    }
+  },
+  "systemJoinHeyWelcomeAboard": "Hey, {username}, welcome aboard!",
+  "@systemJoinHeyWelcomeAboard": {
+    "description": "Randomly selected welcome message that appears as a system message when a user joins a community. Plural placeholder is the new member username. Tone is friendly and warm; keep variety across these strings..",
+    "placeholders": {
+      "username": { "type": "String" }
+    }
+  },
+  "systemJoinGladYouMadeIt": "Glad you made it, {username}!",
+  "@systemJoinGladYouMadeIt": {
+    "description": "Randomly selected welcome message that appears as a system message when a user joins a community. Plural placeholder is the new member username. Tone is friendly and warm; keep variety across these strings..",
+    "placeholders": {
+      "username": { "type": "String" }
+    }
+  },
+  "systemJoinWelcomeIn": "Welcome in, {username}!",
+  "@systemJoinWelcomeIn": {
+    "description": "Randomly selected welcome message that appears as a system message when a user joins a community. Plural placeholder is the new member username. Tone is friendly and warm; keep variety across these strings..",
+    "placeholders": {
+      "username": { "type": "String" }
+    }
+  },
+  "systemJoinWelcome": "Welcome, {username}!",
+  "@systemJoinWelcome": {
+    "description": "Randomly selected welcome message that appears as a system message when a user joins a community. Plural placeholder is the new member username. Tone is friendly and warm; keep variety across these strings..",
+    "placeholders": {
+      "username": { "type": "String" }
+    }
+  },
+  "systemJoinWelcomeWereGladYoureHere": "Welcome, {username}! We're glad you're here.",
+  "@systemJoinWelcomeWereGladYoureHere": {
+    "description": "Randomly selected welcome message that appears as a system message when a user joins a community. Plural placeholder is the new member username. Tone is friendly and warm; keep variety across these strings..",
+    "placeholders": {
+      "username": { "type": "String" }
+    }
+  },
+  "systemJoinWelcomeHopeYouEnjoyYourTimeHere": "Welcome, {username}! Hope you enjoy your time here.",
+  "@systemJoinWelcomeHopeYouEnjoyYourTimeHere": {
+    "description": "Randomly selected welcome message that appears as a system message when a user joins a community. Plural placeholder is the new member username. Tone is friendly and warm; keep variety across these strings..",
+    "placeholders": {
+      "username": { "type": "String" }
+    }
+  },
+  "systemJoinWelcomeYourNextConversationStartsHere": "Welcome, {username}! Your next conversation starts here.",
+  "@systemJoinWelcomeYourNextConversationStartsHere": {
+    "description": "Randomly selected welcome message that appears as a system message when a user joins a community. Plural placeholder is the new member username. Tone is friendly and warm; keep variety across these strings..",
+    "placeholders": {
+      "username": { "type": "String" }
+    }
+  },
+  "systemJoinWelcomeWereHappyToHaveYouHere": "Welcome, {username}. We're happy to have you here.",
+  "@systemJoinWelcomeWereHappyToHaveYouHere": {
+    "description": "Randomly selected welcome message that appears as a system message when a user joins a community. Plural placeholder is the new member username. Tone is friendly and warm; keep variety across these strings..",
+    "placeholders": {
+      "username": { "type": "String" }
+    }
+  },
+  "systemJoinGreatToSeeYouWelcomeIn": "Great to see you, {username}! Welcome in.",
+  "@systemJoinGreatToSeeYouWelcomeIn": {
+    "description": "Randomly selected welcome message that appears as a system message when a user joins a community. Plural placeholder is the new member username. Tone is friendly and warm; keep variety across these strings..",
+    "placeholders": {
+      "username": { "type": "String" }
+    }
+  },
+  "systemJoinYoureHereGoodToHaveYouWithUs": "You're here, {username}! Good to have you with us.",
+  "@systemJoinYoureHereGoodToHaveYouWithUs": {
+    "description": "Randomly selected welcome message that appears as a system message when a user joins a community. Plural placeholder is the new member username. Tone is friendly and warm; keep variety across these strings..",
+    "placeholders": {
+      "username": { "type": "String" }
+    }
+  },
+  "systemJoinYouveArrivedLetsGetStarted": "You've arrived, {username}! Let's get started.",
+  "@systemJoinYouveArrivedLetsGetStarted": {
+    "description": "Randomly selected welcome message that appears as a system message when a user joins a community. Plural placeholder is the new member username. Tone is friendly and warm; keep variety across these strings..",
+    "placeholders": {
+      "username": { "type": "String" }
+    }
+  },
   "relativeTimeShortNow": "now",
   "@relativeTimeShortNow": {
     "description": "Short-form relative time for events less than a minute ago."

--- a/lib/l10n/generated/fluxer_localizations.dart
+++ b/lib/l10n/generated/fluxer_localizations.dart
@@ -4623,6 +4623,108 @@ abstract class FluxerLocalizations {
   /// **'Whoa, it\'s a typing apocalypse'**
   String get typingIndicatorApocalypse;
 
+  /// Randomly selected welcome message that appears as a system message when a user joins a community. Plural placeholder is the new member username. Tone is friendly and warm; keep variety across these strings..
+  ///
+  /// In en, this message translates to:
+  /// **'Glad you\'re here, {username}!'**
+  String systemJoinGladYoureHere(String username);
+
+  /// Randomly selected welcome message that appears as a system message when a user joins a community. Plural placeholder is the new member username. Tone is friendly and warm; keep variety across these strings..
+  ///
+  /// In en, this message translates to:
+  /// **'Welcome, {username}! Make yourself at home.'**
+  String systemJoinWelcomeMakeYourselfAtHome(String username);
+
+  /// Randomly selected welcome message that appears as a system message when a user joins a community. Plural placeholder is the new member username. Tone is friendly and warm; keep variety across these strings..
+  ///
+  /// In en, this message translates to:
+  /// **'Hello, {username}! Nice to have you here.'**
+  String systemJoinHelloNiceToHaveYouHere(String username);
+
+  /// Randomly selected welcome message that appears as a system message when a user joins a community. Plural placeholder is the new member username. Tone is friendly and warm; keep variety across these strings..
+  ///
+  /// In en, this message translates to:
+  /// **'Hello, {username}! Jump in whenever you\'re ready.'**
+  String systemJoinHelloJumpInWheneverYoureReady(String username);
+
+  /// Randomly selected welcome message that appears as a system message when a user joins a community. Plural placeholder is the new member username. Tone is friendly and warm; keep variety across these strings..
+  ///
+  /// In en, this message translates to:
+  /// **'Hey {username}, great to see you here!'**
+  String systemJoinHeyGreatToSeeYouHere(String username);
+
+  /// Randomly selected welcome message that appears as a system message when a user joins a community. Plural placeholder is the new member username. Tone is friendly and warm; keep variety across these strings..
+  ///
+  /// In en, this message translates to:
+  /// **'Hey there, {username}! Hope you enjoy your stay.'**
+  String systemJoinHeyThereHopeYouEnjoyYourStay(String username);
+
+  /// Randomly selected welcome message that appears as a system message when a user joins a community. Plural placeholder is the new member username. Tone is friendly and warm; keep variety across these strings..
+  ///
+  /// In en, this message translates to:
+  /// **'Hey, {username}, welcome aboard!'**
+  String systemJoinHeyWelcomeAboard(String username);
+
+  /// Randomly selected welcome message that appears as a system message when a user joins a community. Plural placeholder is the new member username. Tone is friendly and warm; keep variety across these strings..
+  ///
+  /// In en, this message translates to:
+  /// **'Glad you made it, {username}!'**
+  String systemJoinGladYouMadeIt(String username);
+
+  /// Randomly selected welcome message that appears as a system message when a user joins a community. Plural placeholder is the new member username. Tone is friendly and warm; keep variety across these strings..
+  ///
+  /// In en, this message translates to:
+  /// **'Welcome in, {username}!'**
+  String systemJoinWelcomeIn(String username);
+
+  /// Randomly selected welcome message that appears as a system message when a user joins a community. Plural placeholder is the new member username. Tone is friendly and warm; keep variety across these strings..
+  ///
+  /// In en, this message translates to:
+  /// **'Welcome, {username}!'**
+  String systemJoinWelcome(String username);
+
+  /// Randomly selected welcome message that appears as a system message when a user joins a community. Plural placeholder is the new member username. Tone is friendly and warm; keep variety across these strings..
+  ///
+  /// In en, this message translates to:
+  /// **'Welcome, {username}! We\'re glad you\'re here.'**
+  String systemJoinWelcomeWereGladYoureHere(String username);
+
+  /// Randomly selected welcome message that appears as a system message when a user joins a community. Plural placeholder is the new member username. Tone is friendly and warm; keep variety across these strings..
+  ///
+  /// In en, this message translates to:
+  /// **'Welcome, {username}! Hope you enjoy your time here.'**
+  String systemJoinWelcomeHopeYouEnjoyYourTimeHere(String username);
+
+  /// Randomly selected welcome message that appears as a system message when a user joins a community. Plural placeholder is the new member username. Tone is friendly and warm; keep variety across these strings..
+  ///
+  /// In en, this message translates to:
+  /// **'Welcome, {username}! Your next conversation starts here.'**
+  String systemJoinWelcomeYourNextConversationStartsHere(String username);
+
+  /// Randomly selected welcome message that appears as a system message when a user joins a community. Plural placeholder is the new member username. Tone is friendly and warm; keep variety across these strings..
+  ///
+  /// In en, this message translates to:
+  /// **'Welcome, {username}. We\'re happy to have you here.'**
+  String systemJoinWelcomeWereHappyToHaveYouHere(String username);
+
+  /// Randomly selected welcome message that appears as a system message when a user joins a community. Plural placeholder is the new member username. Tone is friendly and warm; keep variety across these strings..
+  ///
+  /// In en, this message translates to:
+  /// **'Great to see you, {username}! Welcome in.'**
+  String systemJoinGreatToSeeYouWelcomeIn(String username);
+
+  /// Randomly selected welcome message that appears as a system message when a user joins a community. Plural placeholder is the new member username. Tone is friendly and warm; keep variety across these strings..
+  ///
+  /// In en, this message translates to:
+  /// **'You\'re here, {username}! Good to have you with us.'**
+  String systemJoinYoureHereGoodToHaveYouWithUs(String username);
+
+  /// Randomly selected welcome message that appears as a system message when a user joins a community. Plural placeholder is the new member username. Tone is friendly and warm; keep variety across these strings..
+  ///
+  /// In en, this message translates to:
+  /// **'You\'ve arrived, {username}! Let\'s get started.'**
+  String systemJoinYouveArrivedLetsGetStarted(String username);
+
   /// Short-form relative time for events less than a minute ago.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/generated/fluxer_localizations_af.dart
+++ b/lib/l10n/generated/fluxer_localizations_af.dart
@@ -2568,6 +2568,91 @@ class FluxerLocalizationsAf extends FluxerLocalizations {
   String get typingIndicatorApocalypse => 'Whoa, it\'s a typing apocalypse';
 
   @override
+  String systemJoinGladYoureHere(String username) {
+    return 'Glad you\'re here, $username!';
+  }
+
+  @override
+  String systemJoinWelcomeMakeYourselfAtHome(String username) {
+    return 'Welcome, $username! Make yourself at home.';
+  }
+
+  @override
+  String systemJoinHelloNiceToHaveYouHere(String username) {
+    return 'Hello, $username! Nice to have you here.';
+  }
+
+  @override
+  String systemJoinHelloJumpInWheneverYoureReady(String username) {
+    return 'Hello, $username! Jump in whenever you\'re ready.';
+  }
+
+  @override
+  String systemJoinHeyGreatToSeeYouHere(String username) {
+    return 'Hey $username, great to see you here!';
+  }
+
+  @override
+  String systemJoinHeyThereHopeYouEnjoyYourStay(String username) {
+    return 'Hey there, $username! Hope you enjoy your stay.';
+  }
+
+  @override
+  String systemJoinHeyWelcomeAboard(String username) {
+    return 'Hey, $username, welcome aboard!';
+  }
+
+  @override
+  String systemJoinGladYouMadeIt(String username) {
+    return 'Glad you made it, $username!';
+  }
+
+  @override
+  String systemJoinWelcomeIn(String username) {
+    return 'Welcome in, $username!';
+  }
+
+  @override
+  String systemJoinWelcome(String username) {
+    return 'Welcome, $username!';
+  }
+
+  @override
+  String systemJoinWelcomeWereGladYoureHere(String username) {
+    return 'Welcome, $username! We\'re glad you\'re here.';
+  }
+
+  @override
+  String systemJoinWelcomeHopeYouEnjoyYourTimeHere(String username) {
+    return 'Welcome, $username! Hope you enjoy your time here.';
+  }
+
+  @override
+  String systemJoinWelcomeYourNextConversationStartsHere(String username) {
+    return 'Welcome, $username! Your next conversation starts here.';
+  }
+
+  @override
+  String systemJoinWelcomeWereHappyToHaveYouHere(String username) {
+    return 'Welcome, $username. We\'re happy to have you here.';
+  }
+
+  @override
+  String systemJoinGreatToSeeYouWelcomeIn(String username) {
+    return 'Great to see you, $username! Welcome in.';
+  }
+
+  @override
+  String systemJoinYoureHereGoodToHaveYouWithUs(String username) {
+    return 'You\'re here, $username! Good to have you with us.';
+  }
+
+  @override
+  String systemJoinYouveArrivedLetsGetStarted(String username) {
+    return 'You\'ve arrived, $username! Let\'s get started.';
+  }
+
+  @override
   String get relativeTimeShortNow => 'now';
 
   @override

--- a/lib/l10n/generated/fluxer_localizations_ar.dart
+++ b/lib/l10n/generated/fluxer_localizations_ar.dart
@@ -2568,6 +2568,91 @@ class FluxerLocalizationsAr extends FluxerLocalizations {
   String get typingIndicatorApocalypse => 'Whoa, it\'s a typing apocalypse';
 
   @override
+  String systemJoinGladYoureHere(String username) {
+    return 'Glad you\'re here, $username!';
+  }
+
+  @override
+  String systemJoinWelcomeMakeYourselfAtHome(String username) {
+    return 'Welcome, $username! Make yourself at home.';
+  }
+
+  @override
+  String systemJoinHelloNiceToHaveYouHere(String username) {
+    return 'Hello, $username! Nice to have you here.';
+  }
+
+  @override
+  String systemJoinHelloJumpInWheneverYoureReady(String username) {
+    return 'Hello, $username! Jump in whenever you\'re ready.';
+  }
+
+  @override
+  String systemJoinHeyGreatToSeeYouHere(String username) {
+    return 'Hey $username, great to see you here!';
+  }
+
+  @override
+  String systemJoinHeyThereHopeYouEnjoyYourStay(String username) {
+    return 'Hey there, $username! Hope you enjoy your stay.';
+  }
+
+  @override
+  String systemJoinHeyWelcomeAboard(String username) {
+    return 'Hey, $username, welcome aboard!';
+  }
+
+  @override
+  String systemJoinGladYouMadeIt(String username) {
+    return 'Glad you made it, $username!';
+  }
+
+  @override
+  String systemJoinWelcomeIn(String username) {
+    return 'Welcome in, $username!';
+  }
+
+  @override
+  String systemJoinWelcome(String username) {
+    return 'Welcome, $username!';
+  }
+
+  @override
+  String systemJoinWelcomeWereGladYoureHere(String username) {
+    return 'Welcome, $username! We\'re glad you\'re here.';
+  }
+
+  @override
+  String systemJoinWelcomeHopeYouEnjoyYourTimeHere(String username) {
+    return 'Welcome, $username! Hope you enjoy your time here.';
+  }
+
+  @override
+  String systemJoinWelcomeYourNextConversationStartsHere(String username) {
+    return 'Welcome, $username! Your next conversation starts here.';
+  }
+
+  @override
+  String systemJoinWelcomeWereHappyToHaveYouHere(String username) {
+    return 'Welcome, $username. We\'re happy to have you here.';
+  }
+
+  @override
+  String systemJoinGreatToSeeYouWelcomeIn(String username) {
+    return 'Great to see you, $username! Welcome in.';
+  }
+
+  @override
+  String systemJoinYoureHereGoodToHaveYouWithUs(String username) {
+    return 'You\'re here, $username! Good to have you with us.';
+  }
+
+  @override
+  String systemJoinYouveArrivedLetsGetStarted(String username) {
+    return 'You\'ve arrived, $username! Let\'s get started.';
+  }
+
+  @override
   String get relativeTimeShortNow => 'now';
 
   @override

--- a/lib/l10n/generated/fluxer_localizations_cs.dart
+++ b/lib/l10n/generated/fluxer_localizations_cs.dart
@@ -2568,6 +2568,91 @@ class FluxerLocalizationsCs extends FluxerLocalizations {
   String get typingIndicatorApocalypse => 'Whoa, it\'s a typing apocalypse';
 
   @override
+  String systemJoinGladYoureHere(String username) {
+    return 'Glad you\'re here, $username!';
+  }
+
+  @override
+  String systemJoinWelcomeMakeYourselfAtHome(String username) {
+    return 'Welcome, $username! Make yourself at home.';
+  }
+
+  @override
+  String systemJoinHelloNiceToHaveYouHere(String username) {
+    return 'Hello, $username! Nice to have you here.';
+  }
+
+  @override
+  String systemJoinHelloJumpInWheneverYoureReady(String username) {
+    return 'Hello, $username! Jump in whenever you\'re ready.';
+  }
+
+  @override
+  String systemJoinHeyGreatToSeeYouHere(String username) {
+    return 'Hey $username, great to see you here!';
+  }
+
+  @override
+  String systemJoinHeyThereHopeYouEnjoyYourStay(String username) {
+    return 'Hey there, $username! Hope you enjoy your stay.';
+  }
+
+  @override
+  String systemJoinHeyWelcomeAboard(String username) {
+    return 'Hey, $username, welcome aboard!';
+  }
+
+  @override
+  String systemJoinGladYouMadeIt(String username) {
+    return 'Glad you made it, $username!';
+  }
+
+  @override
+  String systemJoinWelcomeIn(String username) {
+    return 'Welcome in, $username!';
+  }
+
+  @override
+  String systemJoinWelcome(String username) {
+    return 'Welcome, $username!';
+  }
+
+  @override
+  String systemJoinWelcomeWereGladYoureHere(String username) {
+    return 'Welcome, $username! We\'re glad you\'re here.';
+  }
+
+  @override
+  String systemJoinWelcomeHopeYouEnjoyYourTimeHere(String username) {
+    return 'Welcome, $username! Hope you enjoy your time here.';
+  }
+
+  @override
+  String systemJoinWelcomeYourNextConversationStartsHere(String username) {
+    return 'Welcome, $username! Your next conversation starts here.';
+  }
+
+  @override
+  String systemJoinWelcomeWereHappyToHaveYouHere(String username) {
+    return 'Welcome, $username. We\'re happy to have you here.';
+  }
+
+  @override
+  String systemJoinGreatToSeeYouWelcomeIn(String username) {
+    return 'Great to see you, $username! Welcome in.';
+  }
+
+  @override
+  String systemJoinYoureHereGoodToHaveYouWithUs(String username) {
+    return 'You\'re here, $username! Good to have you with us.';
+  }
+
+  @override
+  String systemJoinYouveArrivedLetsGetStarted(String username) {
+    return 'You\'ve arrived, $username! Let\'s get started.';
+  }
+
+  @override
   String get relativeTimeShortNow => 'now';
 
   @override

--- a/lib/l10n/generated/fluxer_localizations_cy.dart
+++ b/lib/l10n/generated/fluxer_localizations_cy.dart
@@ -2568,6 +2568,91 @@ class FluxerLocalizationsCy extends FluxerLocalizations {
   String get typingIndicatorApocalypse => 'Whoa, it\'s a typing apocalypse';
 
   @override
+  String systemJoinGladYoureHere(String username) {
+    return 'Glad you\'re here, $username!';
+  }
+
+  @override
+  String systemJoinWelcomeMakeYourselfAtHome(String username) {
+    return 'Welcome, $username! Make yourself at home.';
+  }
+
+  @override
+  String systemJoinHelloNiceToHaveYouHere(String username) {
+    return 'Hello, $username! Nice to have you here.';
+  }
+
+  @override
+  String systemJoinHelloJumpInWheneverYoureReady(String username) {
+    return 'Hello, $username! Jump in whenever you\'re ready.';
+  }
+
+  @override
+  String systemJoinHeyGreatToSeeYouHere(String username) {
+    return 'Hey $username, great to see you here!';
+  }
+
+  @override
+  String systemJoinHeyThereHopeYouEnjoyYourStay(String username) {
+    return 'Hey there, $username! Hope you enjoy your stay.';
+  }
+
+  @override
+  String systemJoinHeyWelcomeAboard(String username) {
+    return 'Hey, $username, welcome aboard!';
+  }
+
+  @override
+  String systemJoinGladYouMadeIt(String username) {
+    return 'Glad you made it, $username!';
+  }
+
+  @override
+  String systemJoinWelcomeIn(String username) {
+    return 'Welcome in, $username!';
+  }
+
+  @override
+  String systemJoinWelcome(String username) {
+    return 'Welcome, $username!';
+  }
+
+  @override
+  String systemJoinWelcomeWereGladYoureHere(String username) {
+    return 'Welcome, $username! We\'re glad you\'re here.';
+  }
+
+  @override
+  String systemJoinWelcomeHopeYouEnjoyYourTimeHere(String username) {
+    return 'Welcome, $username! Hope you enjoy your time here.';
+  }
+
+  @override
+  String systemJoinWelcomeYourNextConversationStartsHere(String username) {
+    return 'Welcome, $username! Your next conversation starts here.';
+  }
+
+  @override
+  String systemJoinWelcomeWereHappyToHaveYouHere(String username) {
+    return 'Welcome, $username. We\'re happy to have you here.';
+  }
+
+  @override
+  String systemJoinGreatToSeeYouWelcomeIn(String username) {
+    return 'Great to see you, $username! Welcome in.';
+  }
+
+  @override
+  String systemJoinYoureHereGoodToHaveYouWithUs(String username) {
+    return 'You\'re here, $username! Good to have you with us.';
+  }
+
+  @override
+  String systemJoinYouveArrivedLetsGetStarted(String username) {
+    return 'You\'ve arrived, $username! Let\'s get started.';
+  }
+
+  @override
   String get relativeTimeShortNow => 'now';
 
   @override

--- a/lib/l10n/generated/fluxer_localizations_da.dart
+++ b/lib/l10n/generated/fluxer_localizations_da.dart
@@ -2568,6 +2568,91 @@ class FluxerLocalizationsDa extends FluxerLocalizations {
   String get typingIndicatorApocalypse => 'Whoa, it\'s a typing apocalypse';
 
   @override
+  String systemJoinGladYoureHere(String username) {
+    return 'Glad you\'re here, $username!';
+  }
+
+  @override
+  String systemJoinWelcomeMakeYourselfAtHome(String username) {
+    return 'Welcome, $username! Make yourself at home.';
+  }
+
+  @override
+  String systemJoinHelloNiceToHaveYouHere(String username) {
+    return 'Hello, $username! Nice to have you here.';
+  }
+
+  @override
+  String systemJoinHelloJumpInWheneverYoureReady(String username) {
+    return 'Hello, $username! Jump in whenever you\'re ready.';
+  }
+
+  @override
+  String systemJoinHeyGreatToSeeYouHere(String username) {
+    return 'Hey $username, great to see you here!';
+  }
+
+  @override
+  String systemJoinHeyThereHopeYouEnjoyYourStay(String username) {
+    return 'Hey there, $username! Hope you enjoy your stay.';
+  }
+
+  @override
+  String systemJoinHeyWelcomeAboard(String username) {
+    return 'Hey, $username, welcome aboard!';
+  }
+
+  @override
+  String systemJoinGladYouMadeIt(String username) {
+    return 'Glad you made it, $username!';
+  }
+
+  @override
+  String systemJoinWelcomeIn(String username) {
+    return 'Welcome in, $username!';
+  }
+
+  @override
+  String systemJoinWelcome(String username) {
+    return 'Welcome, $username!';
+  }
+
+  @override
+  String systemJoinWelcomeWereGladYoureHere(String username) {
+    return 'Welcome, $username! We\'re glad you\'re here.';
+  }
+
+  @override
+  String systemJoinWelcomeHopeYouEnjoyYourTimeHere(String username) {
+    return 'Welcome, $username! Hope you enjoy your time here.';
+  }
+
+  @override
+  String systemJoinWelcomeYourNextConversationStartsHere(String username) {
+    return 'Welcome, $username! Your next conversation starts here.';
+  }
+
+  @override
+  String systemJoinWelcomeWereHappyToHaveYouHere(String username) {
+    return 'Welcome, $username. We\'re happy to have you here.';
+  }
+
+  @override
+  String systemJoinGreatToSeeYouWelcomeIn(String username) {
+    return 'Great to see you, $username! Welcome in.';
+  }
+
+  @override
+  String systemJoinYoureHereGoodToHaveYouWithUs(String username) {
+    return 'You\'re here, $username! Good to have you with us.';
+  }
+
+  @override
+  String systemJoinYouveArrivedLetsGetStarted(String username) {
+    return 'You\'ve arrived, $username! Let\'s get started.';
+  }
+
+  @override
   String get relativeTimeShortNow => 'now';
 
   @override

--- a/lib/l10n/generated/fluxer_localizations_de.dart
+++ b/lib/l10n/generated/fluxer_localizations_de.dart
@@ -2568,6 +2568,91 @@ class FluxerLocalizationsDe extends FluxerLocalizations {
   String get typingIndicatorApocalypse => 'Whoa, it\'s a typing apocalypse';
 
   @override
+  String systemJoinGladYoureHere(String username) {
+    return 'Glad you\'re here, $username!';
+  }
+
+  @override
+  String systemJoinWelcomeMakeYourselfAtHome(String username) {
+    return 'Welcome, $username! Make yourself at home.';
+  }
+
+  @override
+  String systemJoinHelloNiceToHaveYouHere(String username) {
+    return 'Hello, $username! Nice to have you here.';
+  }
+
+  @override
+  String systemJoinHelloJumpInWheneverYoureReady(String username) {
+    return 'Hello, $username! Jump in whenever you\'re ready.';
+  }
+
+  @override
+  String systemJoinHeyGreatToSeeYouHere(String username) {
+    return 'Hey $username, great to see you here!';
+  }
+
+  @override
+  String systemJoinHeyThereHopeYouEnjoyYourStay(String username) {
+    return 'Hey there, $username! Hope you enjoy your stay.';
+  }
+
+  @override
+  String systemJoinHeyWelcomeAboard(String username) {
+    return 'Hey, $username, welcome aboard!';
+  }
+
+  @override
+  String systemJoinGladYouMadeIt(String username) {
+    return 'Glad you made it, $username!';
+  }
+
+  @override
+  String systemJoinWelcomeIn(String username) {
+    return 'Welcome in, $username!';
+  }
+
+  @override
+  String systemJoinWelcome(String username) {
+    return 'Welcome, $username!';
+  }
+
+  @override
+  String systemJoinWelcomeWereGladYoureHere(String username) {
+    return 'Welcome, $username! We\'re glad you\'re here.';
+  }
+
+  @override
+  String systemJoinWelcomeHopeYouEnjoyYourTimeHere(String username) {
+    return 'Welcome, $username! Hope you enjoy your time here.';
+  }
+
+  @override
+  String systemJoinWelcomeYourNextConversationStartsHere(String username) {
+    return 'Welcome, $username! Your next conversation starts here.';
+  }
+
+  @override
+  String systemJoinWelcomeWereHappyToHaveYouHere(String username) {
+    return 'Welcome, $username. We\'re happy to have you here.';
+  }
+
+  @override
+  String systemJoinGreatToSeeYouWelcomeIn(String username) {
+    return 'Great to see you, $username! Welcome in.';
+  }
+
+  @override
+  String systemJoinYoureHereGoodToHaveYouWithUs(String username) {
+    return 'You\'re here, $username! Good to have you with us.';
+  }
+
+  @override
+  String systemJoinYouveArrivedLetsGetStarted(String username) {
+    return 'You\'ve arrived, $username! Let\'s get started.';
+  }
+
+  @override
   String get relativeTimeShortNow => 'now';
 
   @override

--- a/lib/l10n/generated/fluxer_localizations_el.dart
+++ b/lib/l10n/generated/fluxer_localizations_el.dart
@@ -2568,6 +2568,91 @@ class FluxerLocalizationsEl extends FluxerLocalizations {
   String get typingIndicatorApocalypse => 'Whoa, it\'s a typing apocalypse';
 
   @override
+  String systemJoinGladYoureHere(String username) {
+    return 'Glad you\'re here, $username!';
+  }
+
+  @override
+  String systemJoinWelcomeMakeYourselfAtHome(String username) {
+    return 'Welcome, $username! Make yourself at home.';
+  }
+
+  @override
+  String systemJoinHelloNiceToHaveYouHere(String username) {
+    return 'Hello, $username! Nice to have you here.';
+  }
+
+  @override
+  String systemJoinHelloJumpInWheneverYoureReady(String username) {
+    return 'Hello, $username! Jump in whenever you\'re ready.';
+  }
+
+  @override
+  String systemJoinHeyGreatToSeeYouHere(String username) {
+    return 'Hey $username, great to see you here!';
+  }
+
+  @override
+  String systemJoinHeyThereHopeYouEnjoyYourStay(String username) {
+    return 'Hey there, $username! Hope you enjoy your stay.';
+  }
+
+  @override
+  String systemJoinHeyWelcomeAboard(String username) {
+    return 'Hey, $username, welcome aboard!';
+  }
+
+  @override
+  String systemJoinGladYouMadeIt(String username) {
+    return 'Glad you made it, $username!';
+  }
+
+  @override
+  String systemJoinWelcomeIn(String username) {
+    return 'Welcome in, $username!';
+  }
+
+  @override
+  String systemJoinWelcome(String username) {
+    return 'Welcome, $username!';
+  }
+
+  @override
+  String systemJoinWelcomeWereGladYoureHere(String username) {
+    return 'Welcome, $username! We\'re glad you\'re here.';
+  }
+
+  @override
+  String systemJoinWelcomeHopeYouEnjoyYourTimeHere(String username) {
+    return 'Welcome, $username! Hope you enjoy your time here.';
+  }
+
+  @override
+  String systemJoinWelcomeYourNextConversationStartsHere(String username) {
+    return 'Welcome, $username! Your next conversation starts here.';
+  }
+
+  @override
+  String systemJoinWelcomeWereHappyToHaveYouHere(String username) {
+    return 'Welcome, $username. We\'re happy to have you here.';
+  }
+
+  @override
+  String systemJoinGreatToSeeYouWelcomeIn(String username) {
+    return 'Great to see you, $username! Welcome in.';
+  }
+
+  @override
+  String systemJoinYoureHereGoodToHaveYouWithUs(String username) {
+    return 'You\'re here, $username! Good to have you with us.';
+  }
+
+  @override
+  String systemJoinYouveArrivedLetsGetStarted(String username) {
+    return 'You\'ve arrived, $username! Let\'s get started.';
+  }
+
+  @override
   String get relativeTimeShortNow => 'now';
 
   @override

--- a/lib/l10n/generated/fluxer_localizations_en.dart
+++ b/lib/l10n/generated/fluxer_localizations_en.dart
@@ -2568,6 +2568,91 @@ class FluxerLocalizationsEn extends FluxerLocalizations {
   String get typingIndicatorApocalypse => 'Whoa, it\'s a typing apocalypse';
 
   @override
+  String systemJoinGladYoureHere(String username) {
+    return 'Glad you\'re here, $username!';
+  }
+
+  @override
+  String systemJoinWelcomeMakeYourselfAtHome(String username) {
+    return 'Welcome, $username! Make yourself at home.';
+  }
+
+  @override
+  String systemJoinHelloNiceToHaveYouHere(String username) {
+    return 'Hello, $username! Nice to have you here.';
+  }
+
+  @override
+  String systemJoinHelloJumpInWheneverYoureReady(String username) {
+    return 'Hello, $username! Jump in whenever you\'re ready.';
+  }
+
+  @override
+  String systemJoinHeyGreatToSeeYouHere(String username) {
+    return 'Hey $username, great to see you here!';
+  }
+
+  @override
+  String systemJoinHeyThereHopeYouEnjoyYourStay(String username) {
+    return 'Hey there, $username! Hope you enjoy your stay.';
+  }
+
+  @override
+  String systemJoinHeyWelcomeAboard(String username) {
+    return 'Hey, $username, welcome aboard!';
+  }
+
+  @override
+  String systemJoinGladYouMadeIt(String username) {
+    return 'Glad you made it, $username!';
+  }
+
+  @override
+  String systemJoinWelcomeIn(String username) {
+    return 'Welcome in, $username!';
+  }
+
+  @override
+  String systemJoinWelcome(String username) {
+    return 'Welcome, $username!';
+  }
+
+  @override
+  String systemJoinWelcomeWereGladYoureHere(String username) {
+    return 'Welcome, $username! We\'re glad you\'re here.';
+  }
+
+  @override
+  String systemJoinWelcomeHopeYouEnjoyYourTimeHere(String username) {
+    return 'Welcome, $username! Hope you enjoy your time here.';
+  }
+
+  @override
+  String systemJoinWelcomeYourNextConversationStartsHere(String username) {
+    return 'Welcome, $username! Your next conversation starts here.';
+  }
+
+  @override
+  String systemJoinWelcomeWereHappyToHaveYouHere(String username) {
+    return 'Welcome, $username. We\'re happy to have you here.';
+  }
+
+  @override
+  String systemJoinGreatToSeeYouWelcomeIn(String username) {
+    return 'Great to see you, $username! Welcome in.';
+  }
+
+  @override
+  String systemJoinYoureHereGoodToHaveYouWithUs(String username) {
+    return 'You\'re here, $username! Good to have you with us.';
+  }
+
+  @override
+  String systemJoinYouveArrivedLetsGetStarted(String username) {
+    return 'You\'ve arrived, $username! Let\'s get started.';
+  }
+
+  @override
   String get relativeTimeShortNow => 'now';
 
   @override

--- a/lib/l10n/generated/fluxer_localizations_es.dart
+++ b/lib/l10n/generated/fluxer_localizations_es.dart
@@ -2568,6 +2568,91 @@ class FluxerLocalizationsEs extends FluxerLocalizations {
   String get typingIndicatorApocalypse => 'Whoa, it\'s a typing apocalypse';
 
   @override
+  String systemJoinGladYoureHere(String username) {
+    return 'Glad you\'re here, $username!';
+  }
+
+  @override
+  String systemJoinWelcomeMakeYourselfAtHome(String username) {
+    return 'Welcome, $username! Make yourself at home.';
+  }
+
+  @override
+  String systemJoinHelloNiceToHaveYouHere(String username) {
+    return 'Hello, $username! Nice to have you here.';
+  }
+
+  @override
+  String systemJoinHelloJumpInWheneverYoureReady(String username) {
+    return 'Hello, $username! Jump in whenever you\'re ready.';
+  }
+
+  @override
+  String systemJoinHeyGreatToSeeYouHere(String username) {
+    return 'Hey $username, great to see you here!';
+  }
+
+  @override
+  String systemJoinHeyThereHopeYouEnjoyYourStay(String username) {
+    return 'Hey there, $username! Hope you enjoy your stay.';
+  }
+
+  @override
+  String systemJoinHeyWelcomeAboard(String username) {
+    return 'Hey, $username, welcome aboard!';
+  }
+
+  @override
+  String systemJoinGladYouMadeIt(String username) {
+    return 'Glad you made it, $username!';
+  }
+
+  @override
+  String systemJoinWelcomeIn(String username) {
+    return 'Welcome in, $username!';
+  }
+
+  @override
+  String systemJoinWelcome(String username) {
+    return 'Welcome, $username!';
+  }
+
+  @override
+  String systemJoinWelcomeWereGladYoureHere(String username) {
+    return 'Welcome, $username! We\'re glad you\'re here.';
+  }
+
+  @override
+  String systemJoinWelcomeHopeYouEnjoyYourTimeHere(String username) {
+    return 'Welcome, $username! Hope you enjoy your time here.';
+  }
+
+  @override
+  String systemJoinWelcomeYourNextConversationStartsHere(String username) {
+    return 'Welcome, $username! Your next conversation starts here.';
+  }
+
+  @override
+  String systemJoinWelcomeWereHappyToHaveYouHere(String username) {
+    return 'Welcome, $username. We\'re happy to have you here.';
+  }
+
+  @override
+  String systemJoinGreatToSeeYouWelcomeIn(String username) {
+    return 'Great to see you, $username! Welcome in.';
+  }
+
+  @override
+  String systemJoinYoureHereGoodToHaveYouWithUs(String username) {
+    return 'You\'re here, $username! Good to have you with us.';
+  }
+
+  @override
+  String systemJoinYouveArrivedLetsGetStarted(String username) {
+    return 'You\'ve arrived, $username! Let\'s get started.';
+  }
+
+  @override
   String get relativeTimeShortNow => 'now';
 
   @override

--- a/lib/l10n/generated/fluxer_localizations_et.dart
+++ b/lib/l10n/generated/fluxer_localizations_et.dart
@@ -2568,6 +2568,91 @@ class FluxerLocalizationsEt extends FluxerLocalizations {
   String get typingIndicatorApocalypse => 'Whoa, it\'s a typing apocalypse';
 
   @override
+  String systemJoinGladYoureHere(String username) {
+    return 'Glad you\'re here, $username!';
+  }
+
+  @override
+  String systemJoinWelcomeMakeYourselfAtHome(String username) {
+    return 'Welcome, $username! Make yourself at home.';
+  }
+
+  @override
+  String systemJoinHelloNiceToHaveYouHere(String username) {
+    return 'Hello, $username! Nice to have you here.';
+  }
+
+  @override
+  String systemJoinHelloJumpInWheneverYoureReady(String username) {
+    return 'Hello, $username! Jump in whenever you\'re ready.';
+  }
+
+  @override
+  String systemJoinHeyGreatToSeeYouHere(String username) {
+    return 'Hey $username, great to see you here!';
+  }
+
+  @override
+  String systemJoinHeyThereHopeYouEnjoyYourStay(String username) {
+    return 'Hey there, $username! Hope you enjoy your stay.';
+  }
+
+  @override
+  String systemJoinHeyWelcomeAboard(String username) {
+    return 'Hey, $username, welcome aboard!';
+  }
+
+  @override
+  String systemJoinGladYouMadeIt(String username) {
+    return 'Glad you made it, $username!';
+  }
+
+  @override
+  String systemJoinWelcomeIn(String username) {
+    return 'Welcome in, $username!';
+  }
+
+  @override
+  String systemJoinWelcome(String username) {
+    return 'Welcome, $username!';
+  }
+
+  @override
+  String systemJoinWelcomeWereGladYoureHere(String username) {
+    return 'Welcome, $username! We\'re glad you\'re here.';
+  }
+
+  @override
+  String systemJoinWelcomeHopeYouEnjoyYourTimeHere(String username) {
+    return 'Welcome, $username! Hope you enjoy your time here.';
+  }
+
+  @override
+  String systemJoinWelcomeYourNextConversationStartsHere(String username) {
+    return 'Welcome, $username! Your next conversation starts here.';
+  }
+
+  @override
+  String systemJoinWelcomeWereHappyToHaveYouHere(String username) {
+    return 'Welcome, $username. We\'re happy to have you here.';
+  }
+
+  @override
+  String systemJoinGreatToSeeYouWelcomeIn(String username) {
+    return 'Great to see you, $username! Welcome in.';
+  }
+
+  @override
+  String systemJoinYoureHereGoodToHaveYouWithUs(String username) {
+    return 'You\'re here, $username! Good to have you with us.';
+  }
+
+  @override
+  String systemJoinYouveArrivedLetsGetStarted(String username) {
+    return 'You\'ve arrived, $username! Let\'s get started.';
+  }
+
+  @override
   String get relativeTimeShortNow => 'now';
 
   @override

--- a/lib/l10n/generated/fluxer_localizations_fa.dart
+++ b/lib/l10n/generated/fluxer_localizations_fa.dart
@@ -2568,6 +2568,91 @@ class FluxerLocalizationsFa extends FluxerLocalizations {
   String get typingIndicatorApocalypse => 'Whoa, it\'s a typing apocalypse';
 
   @override
+  String systemJoinGladYoureHere(String username) {
+    return 'Glad you\'re here, $username!';
+  }
+
+  @override
+  String systemJoinWelcomeMakeYourselfAtHome(String username) {
+    return 'Welcome, $username! Make yourself at home.';
+  }
+
+  @override
+  String systemJoinHelloNiceToHaveYouHere(String username) {
+    return 'Hello, $username! Nice to have you here.';
+  }
+
+  @override
+  String systemJoinHelloJumpInWheneverYoureReady(String username) {
+    return 'Hello, $username! Jump in whenever you\'re ready.';
+  }
+
+  @override
+  String systemJoinHeyGreatToSeeYouHere(String username) {
+    return 'Hey $username, great to see you here!';
+  }
+
+  @override
+  String systemJoinHeyThereHopeYouEnjoyYourStay(String username) {
+    return 'Hey there, $username! Hope you enjoy your stay.';
+  }
+
+  @override
+  String systemJoinHeyWelcomeAboard(String username) {
+    return 'Hey, $username, welcome aboard!';
+  }
+
+  @override
+  String systemJoinGladYouMadeIt(String username) {
+    return 'Glad you made it, $username!';
+  }
+
+  @override
+  String systemJoinWelcomeIn(String username) {
+    return 'Welcome in, $username!';
+  }
+
+  @override
+  String systemJoinWelcome(String username) {
+    return 'Welcome, $username!';
+  }
+
+  @override
+  String systemJoinWelcomeWereGladYoureHere(String username) {
+    return 'Welcome, $username! We\'re glad you\'re here.';
+  }
+
+  @override
+  String systemJoinWelcomeHopeYouEnjoyYourTimeHere(String username) {
+    return 'Welcome, $username! Hope you enjoy your time here.';
+  }
+
+  @override
+  String systemJoinWelcomeYourNextConversationStartsHere(String username) {
+    return 'Welcome, $username! Your next conversation starts here.';
+  }
+
+  @override
+  String systemJoinWelcomeWereHappyToHaveYouHere(String username) {
+    return 'Welcome, $username. We\'re happy to have you here.';
+  }
+
+  @override
+  String systemJoinGreatToSeeYouWelcomeIn(String username) {
+    return 'Great to see you, $username! Welcome in.';
+  }
+
+  @override
+  String systemJoinYoureHereGoodToHaveYouWithUs(String username) {
+    return 'You\'re here, $username! Good to have you with us.';
+  }
+
+  @override
+  String systemJoinYouveArrivedLetsGetStarted(String username) {
+    return 'You\'ve arrived, $username! Let\'s get started.';
+  }
+
+  @override
   String get relativeTimeShortNow => 'now';
 
   @override

--- a/lib/l10n/generated/fluxer_localizations_fi.dart
+++ b/lib/l10n/generated/fluxer_localizations_fi.dart
@@ -2568,6 +2568,91 @@ class FluxerLocalizationsFi extends FluxerLocalizations {
   String get typingIndicatorApocalypse => 'Whoa, it\'s a typing apocalypse';
 
   @override
+  String systemJoinGladYoureHere(String username) {
+    return 'Glad you\'re here, $username!';
+  }
+
+  @override
+  String systemJoinWelcomeMakeYourselfAtHome(String username) {
+    return 'Welcome, $username! Make yourself at home.';
+  }
+
+  @override
+  String systemJoinHelloNiceToHaveYouHere(String username) {
+    return 'Hello, $username! Nice to have you here.';
+  }
+
+  @override
+  String systemJoinHelloJumpInWheneverYoureReady(String username) {
+    return 'Hello, $username! Jump in whenever you\'re ready.';
+  }
+
+  @override
+  String systemJoinHeyGreatToSeeYouHere(String username) {
+    return 'Hey $username, great to see you here!';
+  }
+
+  @override
+  String systemJoinHeyThereHopeYouEnjoyYourStay(String username) {
+    return 'Hey there, $username! Hope you enjoy your stay.';
+  }
+
+  @override
+  String systemJoinHeyWelcomeAboard(String username) {
+    return 'Hey, $username, welcome aboard!';
+  }
+
+  @override
+  String systemJoinGladYouMadeIt(String username) {
+    return 'Glad you made it, $username!';
+  }
+
+  @override
+  String systemJoinWelcomeIn(String username) {
+    return 'Welcome in, $username!';
+  }
+
+  @override
+  String systemJoinWelcome(String username) {
+    return 'Welcome, $username!';
+  }
+
+  @override
+  String systemJoinWelcomeWereGladYoureHere(String username) {
+    return 'Welcome, $username! We\'re glad you\'re here.';
+  }
+
+  @override
+  String systemJoinWelcomeHopeYouEnjoyYourTimeHere(String username) {
+    return 'Welcome, $username! Hope you enjoy your time here.';
+  }
+
+  @override
+  String systemJoinWelcomeYourNextConversationStartsHere(String username) {
+    return 'Welcome, $username! Your next conversation starts here.';
+  }
+
+  @override
+  String systemJoinWelcomeWereHappyToHaveYouHere(String username) {
+    return 'Welcome, $username. We\'re happy to have you here.';
+  }
+
+  @override
+  String systemJoinGreatToSeeYouWelcomeIn(String username) {
+    return 'Great to see you, $username! Welcome in.';
+  }
+
+  @override
+  String systemJoinYoureHereGoodToHaveYouWithUs(String username) {
+    return 'You\'re here, $username! Good to have you with us.';
+  }
+
+  @override
+  String systemJoinYouveArrivedLetsGetStarted(String username) {
+    return 'You\'ve arrived, $username! Let\'s get started.';
+  }
+
+  @override
   String get relativeTimeShortNow => 'now';
 
   @override

--- a/lib/l10n/generated/fluxer_localizations_fr.dart
+++ b/lib/l10n/generated/fluxer_localizations_fr.dart
@@ -2568,6 +2568,91 @@ class FluxerLocalizationsFr extends FluxerLocalizations {
   String get typingIndicatorApocalypse => 'Whoa, it\'s a typing apocalypse';
 
   @override
+  String systemJoinGladYoureHere(String username) {
+    return 'Glad you\'re here, $username!';
+  }
+
+  @override
+  String systemJoinWelcomeMakeYourselfAtHome(String username) {
+    return 'Welcome, $username! Make yourself at home.';
+  }
+
+  @override
+  String systemJoinHelloNiceToHaveYouHere(String username) {
+    return 'Hello, $username! Nice to have you here.';
+  }
+
+  @override
+  String systemJoinHelloJumpInWheneverYoureReady(String username) {
+    return 'Hello, $username! Jump in whenever you\'re ready.';
+  }
+
+  @override
+  String systemJoinHeyGreatToSeeYouHere(String username) {
+    return 'Hey $username, great to see you here!';
+  }
+
+  @override
+  String systemJoinHeyThereHopeYouEnjoyYourStay(String username) {
+    return 'Hey there, $username! Hope you enjoy your stay.';
+  }
+
+  @override
+  String systemJoinHeyWelcomeAboard(String username) {
+    return 'Hey, $username, welcome aboard!';
+  }
+
+  @override
+  String systemJoinGladYouMadeIt(String username) {
+    return 'Glad you made it, $username!';
+  }
+
+  @override
+  String systemJoinWelcomeIn(String username) {
+    return 'Welcome in, $username!';
+  }
+
+  @override
+  String systemJoinWelcome(String username) {
+    return 'Welcome, $username!';
+  }
+
+  @override
+  String systemJoinWelcomeWereGladYoureHere(String username) {
+    return 'Welcome, $username! We\'re glad you\'re here.';
+  }
+
+  @override
+  String systemJoinWelcomeHopeYouEnjoyYourTimeHere(String username) {
+    return 'Welcome, $username! Hope you enjoy your time here.';
+  }
+
+  @override
+  String systemJoinWelcomeYourNextConversationStartsHere(String username) {
+    return 'Welcome, $username! Your next conversation starts here.';
+  }
+
+  @override
+  String systemJoinWelcomeWereHappyToHaveYouHere(String username) {
+    return 'Welcome, $username. We\'re happy to have you here.';
+  }
+
+  @override
+  String systemJoinGreatToSeeYouWelcomeIn(String username) {
+    return 'Great to see you, $username! Welcome in.';
+  }
+
+  @override
+  String systemJoinYoureHereGoodToHaveYouWithUs(String username) {
+    return 'You\'re here, $username! Good to have you with us.';
+  }
+
+  @override
+  String systemJoinYouveArrivedLetsGetStarted(String username) {
+    return 'You\'ve arrived, $username! Let\'s get started.';
+  }
+
+  @override
   String get relativeTimeShortNow => 'now';
 
   @override

--- a/lib/l10n/generated/fluxer_localizations_ga.dart
+++ b/lib/l10n/generated/fluxer_localizations_ga.dart
@@ -2568,6 +2568,91 @@ class FluxerLocalizationsGa extends FluxerLocalizations {
   String get typingIndicatorApocalypse => 'Whoa, it\'s a typing apocalypse';
 
   @override
+  String systemJoinGladYoureHere(String username) {
+    return 'Glad you\'re here, $username!';
+  }
+
+  @override
+  String systemJoinWelcomeMakeYourselfAtHome(String username) {
+    return 'Welcome, $username! Make yourself at home.';
+  }
+
+  @override
+  String systemJoinHelloNiceToHaveYouHere(String username) {
+    return 'Hello, $username! Nice to have you here.';
+  }
+
+  @override
+  String systemJoinHelloJumpInWheneverYoureReady(String username) {
+    return 'Hello, $username! Jump in whenever you\'re ready.';
+  }
+
+  @override
+  String systemJoinHeyGreatToSeeYouHere(String username) {
+    return 'Hey $username, great to see you here!';
+  }
+
+  @override
+  String systemJoinHeyThereHopeYouEnjoyYourStay(String username) {
+    return 'Hey there, $username! Hope you enjoy your stay.';
+  }
+
+  @override
+  String systemJoinHeyWelcomeAboard(String username) {
+    return 'Hey, $username, welcome aboard!';
+  }
+
+  @override
+  String systemJoinGladYouMadeIt(String username) {
+    return 'Glad you made it, $username!';
+  }
+
+  @override
+  String systemJoinWelcomeIn(String username) {
+    return 'Welcome in, $username!';
+  }
+
+  @override
+  String systemJoinWelcome(String username) {
+    return 'Welcome, $username!';
+  }
+
+  @override
+  String systemJoinWelcomeWereGladYoureHere(String username) {
+    return 'Welcome, $username! We\'re glad you\'re here.';
+  }
+
+  @override
+  String systemJoinWelcomeHopeYouEnjoyYourTimeHere(String username) {
+    return 'Welcome, $username! Hope you enjoy your time here.';
+  }
+
+  @override
+  String systemJoinWelcomeYourNextConversationStartsHere(String username) {
+    return 'Welcome, $username! Your next conversation starts here.';
+  }
+
+  @override
+  String systemJoinWelcomeWereHappyToHaveYouHere(String username) {
+    return 'Welcome, $username. We\'re happy to have you here.';
+  }
+
+  @override
+  String systemJoinGreatToSeeYouWelcomeIn(String username) {
+    return 'Great to see you, $username! Welcome in.';
+  }
+
+  @override
+  String systemJoinYoureHereGoodToHaveYouWithUs(String username) {
+    return 'You\'re here, $username! Good to have you with us.';
+  }
+
+  @override
+  String systemJoinYouveArrivedLetsGetStarted(String username) {
+    return 'You\'ve arrived, $username! Let\'s get started.';
+  }
+
+  @override
   String get relativeTimeShortNow => 'now';
 
   @override

--- a/lib/l10n/generated/fluxer_localizations_gl.dart
+++ b/lib/l10n/generated/fluxer_localizations_gl.dart
@@ -2568,6 +2568,91 @@ class FluxerLocalizationsGl extends FluxerLocalizations {
   String get typingIndicatorApocalypse => 'Whoa, it\'s a typing apocalypse';
 
   @override
+  String systemJoinGladYoureHere(String username) {
+    return 'Glad you\'re here, $username!';
+  }
+
+  @override
+  String systemJoinWelcomeMakeYourselfAtHome(String username) {
+    return 'Welcome, $username! Make yourself at home.';
+  }
+
+  @override
+  String systemJoinHelloNiceToHaveYouHere(String username) {
+    return 'Hello, $username! Nice to have you here.';
+  }
+
+  @override
+  String systemJoinHelloJumpInWheneverYoureReady(String username) {
+    return 'Hello, $username! Jump in whenever you\'re ready.';
+  }
+
+  @override
+  String systemJoinHeyGreatToSeeYouHere(String username) {
+    return 'Hey $username, great to see you here!';
+  }
+
+  @override
+  String systemJoinHeyThereHopeYouEnjoyYourStay(String username) {
+    return 'Hey there, $username! Hope you enjoy your stay.';
+  }
+
+  @override
+  String systemJoinHeyWelcomeAboard(String username) {
+    return 'Hey, $username, welcome aboard!';
+  }
+
+  @override
+  String systemJoinGladYouMadeIt(String username) {
+    return 'Glad you made it, $username!';
+  }
+
+  @override
+  String systemJoinWelcomeIn(String username) {
+    return 'Welcome in, $username!';
+  }
+
+  @override
+  String systemJoinWelcome(String username) {
+    return 'Welcome, $username!';
+  }
+
+  @override
+  String systemJoinWelcomeWereGladYoureHere(String username) {
+    return 'Welcome, $username! We\'re glad you\'re here.';
+  }
+
+  @override
+  String systemJoinWelcomeHopeYouEnjoyYourTimeHere(String username) {
+    return 'Welcome, $username! Hope you enjoy your time here.';
+  }
+
+  @override
+  String systemJoinWelcomeYourNextConversationStartsHere(String username) {
+    return 'Welcome, $username! Your next conversation starts here.';
+  }
+
+  @override
+  String systemJoinWelcomeWereHappyToHaveYouHere(String username) {
+    return 'Welcome, $username. We\'re happy to have you here.';
+  }
+
+  @override
+  String systemJoinGreatToSeeYouWelcomeIn(String username) {
+    return 'Great to see you, $username! Welcome in.';
+  }
+
+  @override
+  String systemJoinYoureHereGoodToHaveYouWithUs(String username) {
+    return 'You\'re here, $username! Good to have you with us.';
+  }
+
+  @override
+  String systemJoinYouveArrivedLetsGetStarted(String username) {
+    return 'You\'ve arrived, $username! Let\'s get started.';
+  }
+
+  @override
   String get relativeTimeShortNow => 'now';
 
   @override

--- a/lib/l10n/generated/fluxer_localizations_hu.dart
+++ b/lib/l10n/generated/fluxer_localizations_hu.dart
@@ -2568,6 +2568,91 @@ class FluxerLocalizationsHu extends FluxerLocalizations {
   String get typingIndicatorApocalypse => 'Whoa, it\'s a typing apocalypse';
 
   @override
+  String systemJoinGladYoureHere(String username) {
+    return 'Glad you\'re here, $username!';
+  }
+
+  @override
+  String systemJoinWelcomeMakeYourselfAtHome(String username) {
+    return 'Welcome, $username! Make yourself at home.';
+  }
+
+  @override
+  String systemJoinHelloNiceToHaveYouHere(String username) {
+    return 'Hello, $username! Nice to have you here.';
+  }
+
+  @override
+  String systemJoinHelloJumpInWheneverYoureReady(String username) {
+    return 'Hello, $username! Jump in whenever you\'re ready.';
+  }
+
+  @override
+  String systemJoinHeyGreatToSeeYouHere(String username) {
+    return 'Hey $username, great to see you here!';
+  }
+
+  @override
+  String systemJoinHeyThereHopeYouEnjoyYourStay(String username) {
+    return 'Hey there, $username! Hope you enjoy your stay.';
+  }
+
+  @override
+  String systemJoinHeyWelcomeAboard(String username) {
+    return 'Hey, $username, welcome aboard!';
+  }
+
+  @override
+  String systemJoinGladYouMadeIt(String username) {
+    return 'Glad you made it, $username!';
+  }
+
+  @override
+  String systemJoinWelcomeIn(String username) {
+    return 'Welcome in, $username!';
+  }
+
+  @override
+  String systemJoinWelcome(String username) {
+    return 'Welcome, $username!';
+  }
+
+  @override
+  String systemJoinWelcomeWereGladYoureHere(String username) {
+    return 'Welcome, $username! We\'re glad you\'re here.';
+  }
+
+  @override
+  String systemJoinWelcomeHopeYouEnjoyYourTimeHere(String username) {
+    return 'Welcome, $username! Hope you enjoy your time here.';
+  }
+
+  @override
+  String systemJoinWelcomeYourNextConversationStartsHere(String username) {
+    return 'Welcome, $username! Your next conversation starts here.';
+  }
+
+  @override
+  String systemJoinWelcomeWereHappyToHaveYouHere(String username) {
+    return 'Welcome, $username. We\'re happy to have you here.';
+  }
+
+  @override
+  String systemJoinGreatToSeeYouWelcomeIn(String username) {
+    return 'Great to see you, $username! Welcome in.';
+  }
+
+  @override
+  String systemJoinYoureHereGoodToHaveYouWithUs(String username) {
+    return 'You\'re here, $username! Good to have you with us.';
+  }
+
+  @override
+  String systemJoinYouveArrivedLetsGetStarted(String username) {
+    return 'You\'ve arrived, $username! Let\'s get started.';
+  }
+
+  @override
   String get relativeTimeShortNow => 'now';
 
   @override

--- a/lib/l10n/generated/fluxer_localizations_is.dart
+++ b/lib/l10n/generated/fluxer_localizations_is.dart
@@ -2568,6 +2568,91 @@ class FluxerLocalizationsIs extends FluxerLocalizations {
   String get typingIndicatorApocalypse => 'Whoa, it\'s a typing apocalypse';
 
   @override
+  String systemJoinGladYoureHere(String username) {
+    return 'Glad you\'re here, $username!';
+  }
+
+  @override
+  String systemJoinWelcomeMakeYourselfAtHome(String username) {
+    return 'Welcome, $username! Make yourself at home.';
+  }
+
+  @override
+  String systemJoinHelloNiceToHaveYouHere(String username) {
+    return 'Hello, $username! Nice to have you here.';
+  }
+
+  @override
+  String systemJoinHelloJumpInWheneverYoureReady(String username) {
+    return 'Hello, $username! Jump in whenever you\'re ready.';
+  }
+
+  @override
+  String systemJoinHeyGreatToSeeYouHere(String username) {
+    return 'Hey $username, great to see you here!';
+  }
+
+  @override
+  String systemJoinHeyThereHopeYouEnjoyYourStay(String username) {
+    return 'Hey there, $username! Hope you enjoy your stay.';
+  }
+
+  @override
+  String systemJoinHeyWelcomeAboard(String username) {
+    return 'Hey, $username, welcome aboard!';
+  }
+
+  @override
+  String systemJoinGladYouMadeIt(String username) {
+    return 'Glad you made it, $username!';
+  }
+
+  @override
+  String systemJoinWelcomeIn(String username) {
+    return 'Welcome in, $username!';
+  }
+
+  @override
+  String systemJoinWelcome(String username) {
+    return 'Welcome, $username!';
+  }
+
+  @override
+  String systemJoinWelcomeWereGladYoureHere(String username) {
+    return 'Welcome, $username! We\'re glad you\'re here.';
+  }
+
+  @override
+  String systemJoinWelcomeHopeYouEnjoyYourTimeHere(String username) {
+    return 'Welcome, $username! Hope you enjoy your time here.';
+  }
+
+  @override
+  String systemJoinWelcomeYourNextConversationStartsHere(String username) {
+    return 'Welcome, $username! Your next conversation starts here.';
+  }
+
+  @override
+  String systemJoinWelcomeWereHappyToHaveYouHere(String username) {
+    return 'Welcome, $username. We\'re happy to have you here.';
+  }
+
+  @override
+  String systemJoinGreatToSeeYouWelcomeIn(String username) {
+    return 'Great to see you, $username! Welcome in.';
+  }
+
+  @override
+  String systemJoinYoureHereGoodToHaveYouWithUs(String username) {
+    return 'You\'re here, $username! Good to have you with us.';
+  }
+
+  @override
+  String systemJoinYouveArrivedLetsGetStarted(String username) {
+    return 'You\'ve arrived, $username! Let\'s get started.';
+  }
+
+  @override
   String get relativeTimeShortNow => 'now';
 
   @override

--- a/lib/l10n/generated/fluxer_localizations_it.dart
+++ b/lib/l10n/generated/fluxer_localizations_it.dart
@@ -2568,6 +2568,91 @@ class FluxerLocalizationsIt extends FluxerLocalizations {
   String get typingIndicatorApocalypse => 'Whoa, it\'s a typing apocalypse';
 
   @override
+  String systemJoinGladYoureHere(String username) {
+    return 'Glad you\'re here, $username!';
+  }
+
+  @override
+  String systemJoinWelcomeMakeYourselfAtHome(String username) {
+    return 'Welcome, $username! Make yourself at home.';
+  }
+
+  @override
+  String systemJoinHelloNiceToHaveYouHere(String username) {
+    return 'Hello, $username! Nice to have you here.';
+  }
+
+  @override
+  String systemJoinHelloJumpInWheneverYoureReady(String username) {
+    return 'Hello, $username! Jump in whenever you\'re ready.';
+  }
+
+  @override
+  String systemJoinHeyGreatToSeeYouHere(String username) {
+    return 'Hey $username, great to see you here!';
+  }
+
+  @override
+  String systemJoinHeyThereHopeYouEnjoyYourStay(String username) {
+    return 'Hey there, $username! Hope you enjoy your stay.';
+  }
+
+  @override
+  String systemJoinHeyWelcomeAboard(String username) {
+    return 'Hey, $username, welcome aboard!';
+  }
+
+  @override
+  String systemJoinGladYouMadeIt(String username) {
+    return 'Glad you made it, $username!';
+  }
+
+  @override
+  String systemJoinWelcomeIn(String username) {
+    return 'Welcome in, $username!';
+  }
+
+  @override
+  String systemJoinWelcome(String username) {
+    return 'Welcome, $username!';
+  }
+
+  @override
+  String systemJoinWelcomeWereGladYoureHere(String username) {
+    return 'Welcome, $username! We\'re glad you\'re here.';
+  }
+
+  @override
+  String systemJoinWelcomeHopeYouEnjoyYourTimeHere(String username) {
+    return 'Welcome, $username! Hope you enjoy your time here.';
+  }
+
+  @override
+  String systemJoinWelcomeYourNextConversationStartsHere(String username) {
+    return 'Welcome, $username! Your next conversation starts here.';
+  }
+
+  @override
+  String systemJoinWelcomeWereHappyToHaveYouHere(String username) {
+    return 'Welcome, $username. We\'re happy to have you here.';
+  }
+
+  @override
+  String systemJoinGreatToSeeYouWelcomeIn(String username) {
+    return 'Great to see you, $username! Welcome in.';
+  }
+
+  @override
+  String systemJoinYoureHereGoodToHaveYouWithUs(String username) {
+    return 'You\'re here, $username! Good to have you with us.';
+  }
+
+  @override
+  String systemJoinYouveArrivedLetsGetStarted(String username) {
+    return 'You\'ve arrived, $username! Let\'s get started.';
+  }
+
+  @override
   String get relativeTimeShortNow => 'now';
 
   @override

--- a/lib/l10n/generated/fluxer_localizations_ja.dart
+++ b/lib/l10n/generated/fluxer_localizations_ja.dart
@@ -2568,6 +2568,91 @@ class FluxerLocalizationsJa extends FluxerLocalizations {
   String get typingIndicatorApocalypse => 'Whoa, it\'s a typing apocalypse';
 
   @override
+  String systemJoinGladYoureHere(String username) {
+    return 'Glad you\'re here, $username!';
+  }
+
+  @override
+  String systemJoinWelcomeMakeYourselfAtHome(String username) {
+    return 'Welcome, $username! Make yourself at home.';
+  }
+
+  @override
+  String systemJoinHelloNiceToHaveYouHere(String username) {
+    return 'Hello, $username! Nice to have you here.';
+  }
+
+  @override
+  String systemJoinHelloJumpInWheneverYoureReady(String username) {
+    return 'Hello, $username! Jump in whenever you\'re ready.';
+  }
+
+  @override
+  String systemJoinHeyGreatToSeeYouHere(String username) {
+    return 'Hey $username, great to see you here!';
+  }
+
+  @override
+  String systemJoinHeyThereHopeYouEnjoyYourStay(String username) {
+    return 'Hey there, $username! Hope you enjoy your stay.';
+  }
+
+  @override
+  String systemJoinHeyWelcomeAboard(String username) {
+    return 'Hey, $username, welcome aboard!';
+  }
+
+  @override
+  String systemJoinGladYouMadeIt(String username) {
+    return 'Glad you made it, $username!';
+  }
+
+  @override
+  String systemJoinWelcomeIn(String username) {
+    return 'Welcome in, $username!';
+  }
+
+  @override
+  String systemJoinWelcome(String username) {
+    return 'Welcome, $username!';
+  }
+
+  @override
+  String systemJoinWelcomeWereGladYoureHere(String username) {
+    return 'Welcome, $username! We\'re glad you\'re here.';
+  }
+
+  @override
+  String systemJoinWelcomeHopeYouEnjoyYourTimeHere(String username) {
+    return 'Welcome, $username! Hope you enjoy your time here.';
+  }
+
+  @override
+  String systemJoinWelcomeYourNextConversationStartsHere(String username) {
+    return 'Welcome, $username! Your next conversation starts here.';
+  }
+
+  @override
+  String systemJoinWelcomeWereHappyToHaveYouHere(String username) {
+    return 'Welcome, $username. We\'re happy to have you here.';
+  }
+
+  @override
+  String systemJoinGreatToSeeYouWelcomeIn(String username) {
+    return 'Great to see you, $username! Welcome in.';
+  }
+
+  @override
+  String systemJoinYoureHereGoodToHaveYouWithUs(String username) {
+    return 'You\'re here, $username! Good to have you with us.';
+  }
+
+  @override
+  String systemJoinYouveArrivedLetsGetStarted(String username) {
+    return 'You\'ve arrived, $username! Let\'s get started.';
+  }
+
+  @override
   String get relativeTimeShortNow => 'now';
 
   @override

--- a/lib/l10n/generated/fluxer_localizations_ko.dart
+++ b/lib/l10n/generated/fluxer_localizations_ko.dart
@@ -2568,6 +2568,91 @@ class FluxerLocalizationsKo extends FluxerLocalizations {
   String get typingIndicatorApocalypse => 'Whoa, it\'s a typing apocalypse';
 
   @override
+  String systemJoinGladYoureHere(String username) {
+    return 'Glad you\'re here, $username!';
+  }
+
+  @override
+  String systemJoinWelcomeMakeYourselfAtHome(String username) {
+    return 'Welcome, $username! Make yourself at home.';
+  }
+
+  @override
+  String systemJoinHelloNiceToHaveYouHere(String username) {
+    return 'Hello, $username! Nice to have you here.';
+  }
+
+  @override
+  String systemJoinHelloJumpInWheneverYoureReady(String username) {
+    return 'Hello, $username! Jump in whenever you\'re ready.';
+  }
+
+  @override
+  String systemJoinHeyGreatToSeeYouHere(String username) {
+    return 'Hey $username, great to see you here!';
+  }
+
+  @override
+  String systemJoinHeyThereHopeYouEnjoyYourStay(String username) {
+    return 'Hey there, $username! Hope you enjoy your stay.';
+  }
+
+  @override
+  String systemJoinHeyWelcomeAboard(String username) {
+    return 'Hey, $username, welcome aboard!';
+  }
+
+  @override
+  String systemJoinGladYouMadeIt(String username) {
+    return 'Glad you made it, $username!';
+  }
+
+  @override
+  String systemJoinWelcomeIn(String username) {
+    return 'Welcome in, $username!';
+  }
+
+  @override
+  String systemJoinWelcome(String username) {
+    return 'Welcome, $username!';
+  }
+
+  @override
+  String systemJoinWelcomeWereGladYoureHere(String username) {
+    return 'Welcome, $username! We\'re glad you\'re here.';
+  }
+
+  @override
+  String systemJoinWelcomeHopeYouEnjoyYourTimeHere(String username) {
+    return 'Welcome, $username! Hope you enjoy your time here.';
+  }
+
+  @override
+  String systemJoinWelcomeYourNextConversationStartsHere(String username) {
+    return 'Welcome, $username! Your next conversation starts here.';
+  }
+
+  @override
+  String systemJoinWelcomeWereHappyToHaveYouHere(String username) {
+    return 'Welcome, $username. We\'re happy to have you here.';
+  }
+
+  @override
+  String systemJoinGreatToSeeYouWelcomeIn(String username) {
+    return 'Great to see you, $username! Welcome in.';
+  }
+
+  @override
+  String systemJoinYoureHereGoodToHaveYouWithUs(String username) {
+    return 'You\'re here, $username! Good to have you with us.';
+  }
+
+  @override
+  String systemJoinYouveArrivedLetsGetStarted(String username) {
+    return 'You\'ve arrived, $username! Let\'s get started.';
+  }
+
+  @override
   String get relativeTimeShortNow => 'now';
 
   @override

--- a/lib/l10n/generated/fluxer_localizations_lt.dart
+++ b/lib/l10n/generated/fluxer_localizations_lt.dart
@@ -2568,6 +2568,91 @@ class FluxerLocalizationsLt extends FluxerLocalizations {
   String get typingIndicatorApocalypse => 'Whoa, it\'s a typing apocalypse';
 
   @override
+  String systemJoinGladYoureHere(String username) {
+    return 'Glad you\'re here, $username!';
+  }
+
+  @override
+  String systemJoinWelcomeMakeYourselfAtHome(String username) {
+    return 'Welcome, $username! Make yourself at home.';
+  }
+
+  @override
+  String systemJoinHelloNiceToHaveYouHere(String username) {
+    return 'Hello, $username! Nice to have you here.';
+  }
+
+  @override
+  String systemJoinHelloJumpInWheneverYoureReady(String username) {
+    return 'Hello, $username! Jump in whenever you\'re ready.';
+  }
+
+  @override
+  String systemJoinHeyGreatToSeeYouHere(String username) {
+    return 'Hey $username, great to see you here!';
+  }
+
+  @override
+  String systemJoinHeyThereHopeYouEnjoyYourStay(String username) {
+    return 'Hey there, $username! Hope you enjoy your stay.';
+  }
+
+  @override
+  String systemJoinHeyWelcomeAboard(String username) {
+    return 'Hey, $username, welcome aboard!';
+  }
+
+  @override
+  String systemJoinGladYouMadeIt(String username) {
+    return 'Glad you made it, $username!';
+  }
+
+  @override
+  String systemJoinWelcomeIn(String username) {
+    return 'Welcome in, $username!';
+  }
+
+  @override
+  String systemJoinWelcome(String username) {
+    return 'Welcome, $username!';
+  }
+
+  @override
+  String systemJoinWelcomeWereGladYoureHere(String username) {
+    return 'Welcome, $username! We\'re glad you\'re here.';
+  }
+
+  @override
+  String systemJoinWelcomeHopeYouEnjoyYourTimeHere(String username) {
+    return 'Welcome, $username! Hope you enjoy your time here.';
+  }
+
+  @override
+  String systemJoinWelcomeYourNextConversationStartsHere(String username) {
+    return 'Welcome, $username! Your next conversation starts here.';
+  }
+
+  @override
+  String systemJoinWelcomeWereHappyToHaveYouHere(String username) {
+    return 'Welcome, $username. We\'re happy to have you here.';
+  }
+
+  @override
+  String systemJoinGreatToSeeYouWelcomeIn(String username) {
+    return 'Great to see you, $username! Welcome in.';
+  }
+
+  @override
+  String systemJoinYoureHereGoodToHaveYouWithUs(String username) {
+    return 'You\'re here, $username! Good to have you with us.';
+  }
+
+  @override
+  String systemJoinYouveArrivedLetsGetStarted(String username) {
+    return 'You\'ve arrived, $username! Let\'s get started.';
+  }
+
+  @override
   String get relativeTimeShortNow => 'now';
 
   @override

--- a/lib/l10n/generated/fluxer_localizations_lv.dart
+++ b/lib/l10n/generated/fluxer_localizations_lv.dart
@@ -2568,6 +2568,91 @@ class FluxerLocalizationsLv extends FluxerLocalizations {
   String get typingIndicatorApocalypse => 'Whoa, it\'s a typing apocalypse';
 
   @override
+  String systemJoinGladYoureHere(String username) {
+    return 'Glad you\'re here, $username!';
+  }
+
+  @override
+  String systemJoinWelcomeMakeYourselfAtHome(String username) {
+    return 'Welcome, $username! Make yourself at home.';
+  }
+
+  @override
+  String systemJoinHelloNiceToHaveYouHere(String username) {
+    return 'Hello, $username! Nice to have you here.';
+  }
+
+  @override
+  String systemJoinHelloJumpInWheneverYoureReady(String username) {
+    return 'Hello, $username! Jump in whenever you\'re ready.';
+  }
+
+  @override
+  String systemJoinHeyGreatToSeeYouHere(String username) {
+    return 'Hey $username, great to see you here!';
+  }
+
+  @override
+  String systemJoinHeyThereHopeYouEnjoyYourStay(String username) {
+    return 'Hey there, $username! Hope you enjoy your stay.';
+  }
+
+  @override
+  String systemJoinHeyWelcomeAboard(String username) {
+    return 'Hey, $username, welcome aboard!';
+  }
+
+  @override
+  String systemJoinGladYouMadeIt(String username) {
+    return 'Glad you made it, $username!';
+  }
+
+  @override
+  String systemJoinWelcomeIn(String username) {
+    return 'Welcome in, $username!';
+  }
+
+  @override
+  String systemJoinWelcome(String username) {
+    return 'Welcome, $username!';
+  }
+
+  @override
+  String systemJoinWelcomeWereGladYoureHere(String username) {
+    return 'Welcome, $username! We\'re glad you\'re here.';
+  }
+
+  @override
+  String systemJoinWelcomeHopeYouEnjoyYourTimeHere(String username) {
+    return 'Welcome, $username! Hope you enjoy your time here.';
+  }
+
+  @override
+  String systemJoinWelcomeYourNextConversationStartsHere(String username) {
+    return 'Welcome, $username! Your next conversation starts here.';
+  }
+
+  @override
+  String systemJoinWelcomeWereHappyToHaveYouHere(String username) {
+    return 'Welcome, $username. We\'re happy to have you here.';
+  }
+
+  @override
+  String systemJoinGreatToSeeYouWelcomeIn(String username) {
+    return 'Great to see you, $username! Welcome in.';
+  }
+
+  @override
+  String systemJoinYoureHereGoodToHaveYouWithUs(String username) {
+    return 'You\'re here, $username! Good to have you with us.';
+  }
+
+  @override
+  String systemJoinYouveArrivedLetsGetStarted(String username) {
+    return 'You\'ve arrived, $username! Let\'s get started.';
+  }
+
+  @override
   String get relativeTimeShortNow => 'now';
 
   @override

--- a/lib/l10n/generated/fluxer_localizations_nb.dart
+++ b/lib/l10n/generated/fluxer_localizations_nb.dart
@@ -2568,6 +2568,91 @@ class FluxerLocalizationsNb extends FluxerLocalizations {
   String get typingIndicatorApocalypse => 'Whoa, it\'s a typing apocalypse';
 
   @override
+  String systemJoinGladYoureHere(String username) {
+    return 'Glad you\'re here, $username!';
+  }
+
+  @override
+  String systemJoinWelcomeMakeYourselfAtHome(String username) {
+    return 'Welcome, $username! Make yourself at home.';
+  }
+
+  @override
+  String systemJoinHelloNiceToHaveYouHere(String username) {
+    return 'Hello, $username! Nice to have you here.';
+  }
+
+  @override
+  String systemJoinHelloJumpInWheneverYoureReady(String username) {
+    return 'Hello, $username! Jump in whenever you\'re ready.';
+  }
+
+  @override
+  String systemJoinHeyGreatToSeeYouHere(String username) {
+    return 'Hey $username, great to see you here!';
+  }
+
+  @override
+  String systemJoinHeyThereHopeYouEnjoyYourStay(String username) {
+    return 'Hey there, $username! Hope you enjoy your stay.';
+  }
+
+  @override
+  String systemJoinHeyWelcomeAboard(String username) {
+    return 'Hey, $username, welcome aboard!';
+  }
+
+  @override
+  String systemJoinGladYouMadeIt(String username) {
+    return 'Glad you made it, $username!';
+  }
+
+  @override
+  String systemJoinWelcomeIn(String username) {
+    return 'Welcome in, $username!';
+  }
+
+  @override
+  String systemJoinWelcome(String username) {
+    return 'Welcome, $username!';
+  }
+
+  @override
+  String systemJoinWelcomeWereGladYoureHere(String username) {
+    return 'Welcome, $username! We\'re glad you\'re here.';
+  }
+
+  @override
+  String systemJoinWelcomeHopeYouEnjoyYourTimeHere(String username) {
+    return 'Welcome, $username! Hope you enjoy your time here.';
+  }
+
+  @override
+  String systemJoinWelcomeYourNextConversationStartsHere(String username) {
+    return 'Welcome, $username! Your next conversation starts here.';
+  }
+
+  @override
+  String systemJoinWelcomeWereHappyToHaveYouHere(String username) {
+    return 'Welcome, $username. We\'re happy to have you here.';
+  }
+
+  @override
+  String systemJoinGreatToSeeYouWelcomeIn(String username) {
+    return 'Great to see you, $username! Welcome in.';
+  }
+
+  @override
+  String systemJoinYoureHereGoodToHaveYouWithUs(String username) {
+    return 'You\'re here, $username! Good to have you with us.';
+  }
+
+  @override
+  String systemJoinYouveArrivedLetsGetStarted(String username) {
+    return 'You\'ve arrived, $username! Let\'s get started.';
+  }
+
+  @override
   String get relativeTimeShortNow => 'now';
 
   @override

--- a/lib/l10n/generated/fluxer_localizations_pl.dart
+++ b/lib/l10n/generated/fluxer_localizations_pl.dart
@@ -2568,6 +2568,91 @@ class FluxerLocalizationsPl extends FluxerLocalizations {
   String get typingIndicatorApocalypse => 'Whoa, it\'s a typing apocalypse';
 
   @override
+  String systemJoinGladYoureHere(String username) {
+    return 'Glad you\'re here, $username!';
+  }
+
+  @override
+  String systemJoinWelcomeMakeYourselfAtHome(String username) {
+    return 'Welcome, $username! Make yourself at home.';
+  }
+
+  @override
+  String systemJoinHelloNiceToHaveYouHere(String username) {
+    return 'Hello, $username! Nice to have you here.';
+  }
+
+  @override
+  String systemJoinHelloJumpInWheneverYoureReady(String username) {
+    return 'Hello, $username! Jump in whenever you\'re ready.';
+  }
+
+  @override
+  String systemJoinHeyGreatToSeeYouHere(String username) {
+    return 'Hey $username, great to see you here!';
+  }
+
+  @override
+  String systemJoinHeyThereHopeYouEnjoyYourStay(String username) {
+    return 'Hey there, $username! Hope you enjoy your stay.';
+  }
+
+  @override
+  String systemJoinHeyWelcomeAboard(String username) {
+    return 'Hey, $username, welcome aboard!';
+  }
+
+  @override
+  String systemJoinGladYouMadeIt(String username) {
+    return 'Glad you made it, $username!';
+  }
+
+  @override
+  String systemJoinWelcomeIn(String username) {
+    return 'Welcome in, $username!';
+  }
+
+  @override
+  String systemJoinWelcome(String username) {
+    return 'Welcome, $username!';
+  }
+
+  @override
+  String systemJoinWelcomeWereGladYoureHere(String username) {
+    return 'Welcome, $username! We\'re glad you\'re here.';
+  }
+
+  @override
+  String systemJoinWelcomeHopeYouEnjoyYourTimeHere(String username) {
+    return 'Welcome, $username! Hope you enjoy your time here.';
+  }
+
+  @override
+  String systemJoinWelcomeYourNextConversationStartsHere(String username) {
+    return 'Welcome, $username! Your next conversation starts here.';
+  }
+
+  @override
+  String systemJoinWelcomeWereHappyToHaveYouHere(String username) {
+    return 'Welcome, $username. We\'re happy to have you here.';
+  }
+
+  @override
+  String systemJoinGreatToSeeYouWelcomeIn(String username) {
+    return 'Great to see you, $username! Welcome in.';
+  }
+
+  @override
+  String systemJoinYoureHereGoodToHaveYouWithUs(String username) {
+    return 'You\'re here, $username! Good to have you with us.';
+  }
+
+  @override
+  String systemJoinYouveArrivedLetsGetStarted(String username) {
+    return 'You\'ve arrived, $username! Let\'s get started.';
+  }
+
+  @override
   String get relativeTimeShortNow => 'now';
 
   @override

--- a/lib/l10n/generated/fluxer_localizations_pt.dart
+++ b/lib/l10n/generated/fluxer_localizations_pt.dart
@@ -2568,6 +2568,91 @@ class FluxerLocalizationsPt extends FluxerLocalizations {
   String get typingIndicatorApocalypse => 'Whoa, it\'s a typing apocalypse';
 
   @override
+  String systemJoinGladYoureHere(String username) {
+    return 'Glad you\'re here, $username!';
+  }
+
+  @override
+  String systemJoinWelcomeMakeYourselfAtHome(String username) {
+    return 'Welcome, $username! Make yourself at home.';
+  }
+
+  @override
+  String systemJoinHelloNiceToHaveYouHere(String username) {
+    return 'Hello, $username! Nice to have you here.';
+  }
+
+  @override
+  String systemJoinHelloJumpInWheneverYoureReady(String username) {
+    return 'Hello, $username! Jump in whenever you\'re ready.';
+  }
+
+  @override
+  String systemJoinHeyGreatToSeeYouHere(String username) {
+    return 'Hey $username, great to see you here!';
+  }
+
+  @override
+  String systemJoinHeyThereHopeYouEnjoyYourStay(String username) {
+    return 'Hey there, $username! Hope you enjoy your stay.';
+  }
+
+  @override
+  String systemJoinHeyWelcomeAboard(String username) {
+    return 'Hey, $username, welcome aboard!';
+  }
+
+  @override
+  String systemJoinGladYouMadeIt(String username) {
+    return 'Glad you made it, $username!';
+  }
+
+  @override
+  String systemJoinWelcomeIn(String username) {
+    return 'Welcome in, $username!';
+  }
+
+  @override
+  String systemJoinWelcome(String username) {
+    return 'Welcome, $username!';
+  }
+
+  @override
+  String systemJoinWelcomeWereGladYoureHere(String username) {
+    return 'Welcome, $username! We\'re glad you\'re here.';
+  }
+
+  @override
+  String systemJoinWelcomeHopeYouEnjoyYourTimeHere(String username) {
+    return 'Welcome, $username! Hope you enjoy your time here.';
+  }
+
+  @override
+  String systemJoinWelcomeYourNextConversationStartsHere(String username) {
+    return 'Welcome, $username! Your next conversation starts here.';
+  }
+
+  @override
+  String systemJoinWelcomeWereHappyToHaveYouHere(String username) {
+    return 'Welcome, $username. We\'re happy to have you here.';
+  }
+
+  @override
+  String systemJoinGreatToSeeYouWelcomeIn(String username) {
+    return 'Great to see you, $username! Welcome in.';
+  }
+
+  @override
+  String systemJoinYoureHereGoodToHaveYouWithUs(String username) {
+    return 'You\'re here, $username! Good to have you with us.';
+  }
+
+  @override
+  String systemJoinYouveArrivedLetsGetStarted(String username) {
+    return 'You\'ve arrived, $username! Let\'s get started.';
+  }
+
+  @override
   String get relativeTimeShortNow => 'now';
 
   @override

--- a/lib/l10n/generated/fluxer_localizations_ru.dart
+++ b/lib/l10n/generated/fluxer_localizations_ru.dart
@@ -2568,6 +2568,91 @@ class FluxerLocalizationsRu extends FluxerLocalizations {
   String get typingIndicatorApocalypse => 'Whoa, it\'s a typing apocalypse';
 
   @override
+  String systemJoinGladYoureHere(String username) {
+    return 'Glad you\'re here, $username!';
+  }
+
+  @override
+  String systemJoinWelcomeMakeYourselfAtHome(String username) {
+    return 'Welcome, $username! Make yourself at home.';
+  }
+
+  @override
+  String systemJoinHelloNiceToHaveYouHere(String username) {
+    return 'Hello, $username! Nice to have you here.';
+  }
+
+  @override
+  String systemJoinHelloJumpInWheneverYoureReady(String username) {
+    return 'Hello, $username! Jump in whenever you\'re ready.';
+  }
+
+  @override
+  String systemJoinHeyGreatToSeeYouHere(String username) {
+    return 'Hey $username, great to see you here!';
+  }
+
+  @override
+  String systemJoinHeyThereHopeYouEnjoyYourStay(String username) {
+    return 'Hey there, $username! Hope you enjoy your stay.';
+  }
+
+  @override
+  String systemJoinHeyWelcomeAboard(String username) {
+    return 'Hey, $username, welcome aboard!';
+  }
+
+  @override
+  String systemJoinGladYouMadeIt(String username) {
+    return 'Glad you made it, $username!';
+  }
+
+  @override
+  String systemJoinWelcomeIn(String username) {
+    return 'Welcome in, $username!';
+  }
+
+  @override
+  String systemJoinWelcome(String username) {
+    return 'Welcome, $username!';
+  }
+
+  @override
+  String systemJoinWelcomeWereGladYoureHere(String username) {
+    return 'Welcome, $username! We\'re glad you\'re here.';
+  }
+
+  @override
+  String systemJoinWelcomeHopeYouEnjoyYourTimeHere(String username) {
+    return 'Welcome, $username! Hope you enjoy your time here.';
+  }
+
+  @override
+  String systemJoinWelcomeYourNextConversationStartsHere(String username) {
+    return 'Welcome, $username! Your next conversation starts here.';
+  }
+
+  @override
+  String systemJoinWelcomeWereHappyToHaveYouHere(String username) {
+    return 'Welcome, $username. We\'re happy to have you here.';
+  }
+
+  @override
+  String systemJoinGreatToSeeYouWelcomeIn(String username) {
+    return 'Great to see you, $username! Welcome in.';
+  }
+
+  @override
+  String systemJoinYoureHereGoodToHaveYouWithUs(String username) {
+    return 'You\'re here, $username! Good to have you with us.';
+  }
+
+  @override
+  String systemJoinYouveArrivedLetsGetStarted(String username) {
+    return 'You\'ve arrived, $username! Let\'s get started.';
+  }
+
+  @override
   String get relativeTimeShortNow => 'now';
 
   @override

--- a/lib/l10n/generated/fluxer_localizations_sk.dart
+++ b/lib/l10n/generated/fluxer_localizations_sk.dart
@@ -2568,6 +2568,91 @@ class FluxerLocalizationsSk extends FluxerLocalizations {
   String get typingIndicatorApocalypse => 'Whoa, it\'s a typing apocalypse';
 
   @override
+  String systemJoinGladYoureHere(String username) {
+    return 'Glad you\'re here, $username!';
+  }
+
+  @override
+  String systemJoinWelcomeMakeYourselfAtHome(String username) {
+    return 'Welcome, $username! Make yourself at home.';
+  }
+
+  @override
+  String systemJoinHelloNiceToHaveYouHere(String username) {
+    return 'Hello, $username! Nice to have you here.';
+  }
+
+  @override
+  String systemJoinHelloJumpInWheneverYoureReady(String username) {
+    return 'Hello, $username! Jump in whenever you\'re ready.';
+  }
+
+  @override
+  String systemJoinHeyGreatToSeeYouHere(String username) {
+    return 'Hey $username, great to see you here!';
+  }
+
+  @override
+  String systemJoinHeyThereHopeYouEnjoyYourStay(String username) {
+    return 'Hey there, $username! Hope you enjoy your stay.';
+  }
+
+  @override
+  String systemJoinHeyWelcomeAboard(String username) {
+    return 'Hey, $username, welcome aboard!';
+  }
+
+  @override
+  String systemJoinGladYouMadeIt(String username) {
+    return 'Glad you made it, $username!';
+  }
+
+  @override
+  String systemJoinWelcomeIn(String username) {
+    return 'Welcome in, $username!';
+  }
+
+  @override
+  String systemJoinWelcome(String username) {
+    return 'Welcome, $username!';
+  }
+
+  @override
+  String systemJoinWelcomeWereGladYoureHere(String username) {
+    return 'Welcome, $username! We\'re glad you\'re here.';
+  }
+
+  @override
+  String systemJoinWelcomeHopeYouEnjoyYourTimeHere(String username) {
+    return 'Welcome, $username! Hope you enjoy your time here.';
+  }
+
+  @override
+  String systemJoinWelcomeYourNextConversationStartsHere(String username) {
+    return 'Welcome, $username! Your next conversation starts here.';
+  }
+
+  @override
+  String systemJoinWelcomeWereHappyToHaveYouHere(String username) {
+    return 'Welcome, $username. We\'re happy to have you here.';
+  }
+
+  @override
+  String systemJoinGreatToSeeYouWelcomeIn(String username) {
+    return 'Great to see you, $username! Welcome in.';
+  }
+
+  @override
+  String systemJoinYoureHereGoodToHaveYouWithUs(String username) {
+    return 'You\'re here, $username! Good to have you with us.';
+  }
+
+  @override
+  String systemJoinYouveArrivedLetsGetStarted(String username) {
+    return 'You\'ve arrived, $username! Let\'s get started.';
+  }
+
+  @override
   String get relativeTimeShortNow => 'now';
 
   @override

--- a/lib/l10n/generated/fluxer_localizations_sl.dart
+++ b/lib/l10n/generated/fluxer_localizations_sl.dart
@@ -2568,6 +2568,91 @@ class FluxerLocalizationsSl extends FluxerLocalizations {
   String get typingIndicatorApocalypse => 'Whoa, it\'s a typing apocalypse';
 
   @override
+  String systemJoinGladYoureHere(String username) {
+    return 'Glad you\'re here, $username!';
+  }
+
+  @override
+  String systemJoinWelcomeMakeYourselfAtHome(String username) {
+    return 'Welcome, $username! Make yourself at home.';
+  }
+
+  @override
+  String systemJoinHelloNiceToHaveYouHere(String username) {
+    return 'Hello, $username! Nice to have you here.';
+  }
+
+  @override
+  String systemJoinHelloJumpInWheneverYoureReady(String username) {
+    return 'Hello, $username! Jump in whenever you\'re ready.';
+  }
+
+  @override
+  String systemJoinHeyGreatToSeeYouHere(String username) {
+    return 'Hey $username, great to see you here!';
+  }
+
+  @override
+  String systemJoinHeyThereHopeYouEnjoyYourStay(String username) {
+    return 'Hey there, $username! Hope you enjoy your stay.';
+  }
+
+  @override
+  String systemJoinHeyWelcomeAboard(String username) {
+    return 'Hey, $username, welcome aboard!';
+  }
+
+  @override
+  String systemJoinGladYouMadeIt(String username) {
+    return 'Glad you made it, $username!';
+  }
+
+  @override
+  String systemJoinWelcomeIn(String username) {
+    return 'Welcome in, $username!';
+  }
+
+  @override
+  String systemJoinWelcome(String username) {
+    return 'Welcome, $username!';
+  }
+
+  @override
+  String systemJoinWelcomeWereGladYoureHere(String username) {
+    return 'Welcome, $username! We\'re glad you\'re here.';
+  }
+
+  @override
+  String systemJoinWelcomeHopeYouEnjoyYourTimeHere(String username) {
+    return 'Welcome, $username! Hope you enjoy your time here.';
+  }
+
+  @override
+  String systemJoinWelcomeYourNextConversationStartsHere(String username) {
+    return 'Welcome, $username! Your next conversation starts here.';
+  }
+
+  @override
+  String systemJoinWelcomeWereHappyToHaveYouHere(String username) {
+    return 'Welcome, $username. We\'re happy to have you here.';
+  }
+
+  @override
+  String systemJoinGreatToSeeYouWelcomeIn(String username) {
+    return 'Great to see you, $username! Welcome in.';
+  }
+
+  @override
+  String systemJoinYoureHereGoodToHaveYouWithUs(String username) {
+    return 'You\'re here, $username! Good to have you with us.';
+  }
+
+  @override
+  String systemJoinYouveArrivedLetsGetStarted(String username) {
+    return 'You\'ve arrived, $username! Let\'s get started.';
+  }
+
+  @override
   String get relativeTimeShortNow => 'now';
 
   @override

--- a/lib/l10n/generated/fluxer_localizations_sr.dart
+++ b/lib/l10n/generated/fluxer_localizations_sr.dart
@@ -2568,6 +2568,91 @@ class FluxerLocalizationsSr extends FluxerLocalizations {
   String get typingIndicatorApocalypse => 'Whoa, it\'s a typing apocalypse';
 
   @override
+  String systemJoinGladYoureHere(String username) {
+    return 'Glad you\'re here, $username!';
+  }
+
+  @override
+  String systemJoinWelcomeMakeYourselfAtHome(String username) {
+    return 'Welcome, $username! Make yourself at home.';
+  }
+
+  @override
+  String systemJoinHelloNiceToHaveYouHere(String username) {
+    return 'Hello, $username! Nice to have you here.';
+  }
+
+  @override
+  String systemJoinHelloJumpInWheneverYoureReady(String username) {
+    return 'Hello, $username! Jump in whenever you\'re ready.';
+  }
+
+  @override
+  String systemJoinHeyGreatToSeeYouHere(String username) {
+    return 'Hey $username, great to see you here!';
+  }
+
+  @override
+  String systemJoinHeyThereHopeYouEnjoyYourStay(String username) {
+    return 'Hey there, $username! Hope you enjoy your stay.';
+  }
+
+  @override
+  String systemJoinHeyWelcomeAboard(String username) {
+    return 'Hey, $username, welcome aboard!';
+  }
+
+  @override
+  String systemJoinGladYouMadeIt(String username) {
+    return 'Glad you made it, $username!';
+  }
+
+  @override
+  String systemJoinWelcomeIn(String username) {
+    return 'Welcome in, $username!';
+  }
+
+  @override
+  String systemJoinWelcome(String username) {
+    return 'Welcome, $username!';
+  }
+
+  @override
+  String systemJoinWelcomeWereGladYoureHere(String username) {
+    return 'Welcome, $username! We\'re glad you\'re here.';
+  }
+
+  @override
+  String systemJoinWelcomeHopeYouEnjoyYourTimeHere(String username) {
+    return 'Welcome, $username! Hope you enjoy your time here.';
+  }
+
+  @override
+  String systemJoinWelcomeYourNextConversationStartsHere(String username) {
+    return 'Welcome, $username! Your next conversation starts here.';
+  }
+
+  @override
+  String systemJoinWelcomeWereHappyToHaveYouHere(String username) {
+    return 'Welcome, $username. We\'re happy to have you here.';
+  }
+
+  @override
+  String systemJoinGreatToSeeYouWelcomeIn(String username) {
+    return 'Great to see you, $username! Welcome in.';
+  }
+
+  @override
+  String systemJoinYoureHereGoodToHaveYouWithUs(String username) {
+    return 'You\'re here, $username! Good to have you with us.';
+  }
+
+  @override
+  String systemJoinYouveArrivedLetsGetStarted(String username) {
+    return 'You\'ve arrived, $username! Let\'s get started.';
+  }
+
+  @override
   String get relativeTimeShortNow => 'now';
 
   @override

--- a/lib/l10n/generated/fluxer_localizations_sv.dart
+++ b/lib/l10n/generated/fluxer_localizations_sv.dart
@@ -2568,6 +2568,91 @@ class FluxerLocalizationsSv extends FluxerLocalizations {
   String get typingIndicatorApocalypse => 'Whoa, it\'s a typing apocalypse';
 
   @override
+  String systemJoinGladYoureHere(String username) {
+    return 'Glad you\'re here, $username!';
+  }
+
+  @override
+  String systemJoinWelcomeMakeYourselfAtHome(String username) {
+    return 'Welcome, $username! Make yourself at home.';
+  }
+
+  @override
+  String systemJoinHelloNiceToHaveYouHere(String username) {
+    return 'Hello, $username! Nice to have you here.';
+  }
+
+  @override
+  String systemJoinHelloJumpInWheneverYoureReady(String username) {
+    return 'Hello, $username! Jump in whenever you\'re ready.';
+  }
+
+  @override
+  String systemJoinHeyGreatToSeeYouHere(String username) {
+    return 'Hey $username, great to see you here!';
+  }
+
+  @override
+  String systemJoinHeyThereHopeYouEnjoyYourStay(String username) {
+    return 'Hey there, $username! Hope you enjoy your stay.';
+  }
+
+  @override
+  String systemJoinHeyWelcomeAboard(String username) {
+    return 'Hey, $username, welcome aboard!';
+  }
+
+  @override
+  String systemJoinGladYouMadeIt(String username) {
+    return 'Glad you made it, $username!';
+  }
+
+  @override
+  String systemJoinWelcomeIn(String username) {
+    return 'Welcome in, $username!';
+  }
+
+  @override
+  String systemJoinWelcome(String username) {
+    return 'Welcome, $username!';
+  }
+
+  @override
+  String systemJoinWelcomeWereGladYoureHere(String username) {
+    return 'Welcome, $username! We\'re glad you\'re here.';
+  }
+
+  @override
+  String systemJoinWelcomeHopeYouEnjoyYourTimeHere(String username) {
+    return 'Welcome, $username! Hope you enjoy your time here.';
+  }
+
+  @override
+  String systemJoinWelcomeYourNextConversationStartsHere(String username) {
+    return 'Welcome, $username! Your next conversation starts here.';
+  }
+
+  @override
+  String systemJoinWelcomeWereHappyToHaveYouHere(String username) {
+    return 'Welcome, $username. We\'re happy to have you here.';
+  }
+
+  @override
+  String systemJoinGreatToSeeYouWelcomeIn(String username) {
+    return 'Great to see you, $username! Welcome in.';
+  }
+
+  @override
+  String systemJoinYoureHereGoodToHaveYouWithUs(String username) {
+    return 'You\'re here, $username! Good to have you with us.';
+  }
+
+  @override
+  String systemJoinYouveArrivedLetsGetStarted(String username) {
+    return 'You\'ve arrived, $username! Let\'s get started.';
+  }
+
+  @override
   String get relativeTimeShortNow => 'now';
 
   @override

--- a/lib/l10n/generated/fluxer_localizations_th.dart
+++ b/lib/l10n/generated/fluxer_localizations_th.dart
@@ -2568,6 +2568,91 @@ class FluxerLocalizationsTh extends FluxerLocalizations {
   String get typingIndicatorApocalypse => 'Whoa, it\'s a typing apocalypse';
 
   @override
+  String systemJoinGladYoureHere(String username) {
+    return 'Glad you\'re here, $username!';
+  }
+
+  @override
+  String systemJoinWelcomeMakeYourselfAtHome(String username) {
+    return 'Welcome, $username! Make yourself at home.';
+  }
+
+  @override
+  String systemJoinHelloNiceToHaveYouHere(String username) {
+    return 'Hello, $username! Nice to have you here.';
+  }
+
+  @override
+  String systemJoinHelloJumpInWheneverYoureReady(String username) {
+    return 'Hello, $username! Jump in whenever you\'re ready.';
+  }
+
+  @override
+  String systemJoinHeyGreatToSeeYouHere(String username) {
+    return 'Hey $username, great to see you here!';
+  }
+
+  @override
+  String systemJoinHeyThereHopeYouEnjoyYourStay(String username) {
+    return 'Hey there, $username! Hope you enjoy your stay.';
+  }
+
+  @override
+  String systemJoinHeyWelcomeAboard(String username) {
+    return 'Hey, $username, welcome aboard!';
+  }
+
+  @override
+  String systemJoinGladYouMadeIt(String username) {
+    return 'Glad you made it, $username!';
+  }
+
+  @override
+  String systemJoinWelcomeIn(String username) {
+    return 'Welcome in, $username!';
+  }
+
+  @override
+  String systemJoinWelcome(String username) {
+    return 'Welcome, $username!';
+  }
+
+  @override
+  String systemJoinWelcomeWereGladYoureHere(String username) {
+    return 'Welcome, $username! We\'re glad you\'re here.';
+  }
+
+  @override
+  String systemJoinWelcomeHopeYouEnjoyYourTimeHere(String username) {
+    return 'Welcome, $username! Hope you enjoy your time here.';
+  }
+
+  @override
+  String systemJoinWelcomeYourNextConversationStartsHere(String username) {
+    return 'Welcome, $username! Your next conversation starts here.';
+  }
+
+  @override
+  String systemJoinWelcomeWereHappyToHaveYouHere(String username) {
+    return 'Welcome, $username. We\'re happy to have you here.';
+  }
+
+  @override
+  String systemJoinGreatToSeeYouWelcomeIn(String username) {
+    return 'Great to see you, $username! Welcome in.';
+  }
+
+  @override
+  String systemJoinYoureHereGoodToHaveYouWithUs(String username) {
+    return 'You\'re here, $username! Good to have you with us.';
+  }
+
+  @override
+  String systemJoinYouveArrivedLetsGetStarted(String username) {
+    return 'You\'ve arrived, $username! Let\'s get started.';
+  }
+
+  @override
   String get relativeTimeShortNow => 'now';
 
   @override

--- a/lib/l10n/generated/fluxer_localizations_tr.dart
+++ b/lib/l10n/generated/fluxer_localizations_tr.dart
@@ -2568,6 +2568,91 @@ class FluxerLocalizationsTr extends FluxerLocalizations {
   String get typingIndicatorApocalypse => 'Whoa, it\'s a typing apocalypse';
 
   @override
+  String systemJoinGladYoureHere(String username) {
+    return 'Glad you\'re here, $username!';
+  }
+
+  @override
+  String systemJoinWelcomeMakeYourselfAtHome(String username) {
+    return 'Welcome, $username! Make yourself at home.';
+  }
+
+  @override
+  String systemJoinHelloNiceToHaveYouHere(String username) {
+    return 'Hello, $username! Nice to have you here.';
+  }
+
+  @override
+  String systemJoinHelloJumpInWheneverYoureReady(String username) {
+    return 'Hello, $username! Jump in whenever you\'re ready.';
+  }
+
+  @override
+  String systemJoinHeyGreatToSeeYouHere(String username) {
+    return 'Hey $username, great to see you here!';
+  }
+
+  @override
+  String systemJoinHeyThereHopeYouEnjoyYourStay(String username) {
+    return 'Hey there, $username! Hope you enjoy your stay.';
+  }
+
+  @override
+  String systemJoinHeyWelcomeAboard(String username) {
+    return 'Hey, $username, welcome aboard!';
+  }
+
+  @override
+  String systemJoinGladYouMadeIt(String username) {
+    return 'Glad you made it, $username!';
+  }
+
+  @override
+  String systemJoinWelcomeIn(String username) {
+    return 'Welcome in, $username!';
+  }
+
+  @override
+  String systemJoinWelcome(String username) {
+    return 'Welcome, $username!';
+  }
+
+  @override
+  String systemJoinWelcomeWereGladYoureHere(String username) {
+    return 'Welcome, $username! We\'re glad you\'re here.';
+  }
+
+  @override
+  String systemJoinWelcomeHopeYouEnjoyYourTimeHere(String username) {
+    return 'Welcome, $username! Hope you enjoy your time here.';
+  }
+
+  @override
+  String systemJoinWelcomeYourNextConversationStartsHere(String username) {
+    return 'Welcome, $username! Your next conversation starts here.';
+  }
+
+  @override
+  String systemJoinWelcomeWereHappyToHaveYouHere(String username) {
+    return 'Welcome, $username. We\'re happy to have you here.';
+  }
+
+  @override
+  String systemJoinGreatToSeeYouWelcomeIn(String username) {
+    return 'Great to see you, $username! Welcome in.';
+  }
+
+  @override
+  String systemJoinYoureHereGoodToHaveYouWithUs(String username) {
+    return 'You\'re here, $username! Good to have you with us.';
+  }
+
+  @override
+  String systemJoinYouveArrivedLetsGetStarted(String username) {
+    return 'You\'ve arrived, $username! Let\'s get started.';
+  }
+
+  @override
   String get relativeTimeShortNow => 'now';
 
   @override

--- a/lib/l10n/generated/fluxer_localizations_uk.dart
+++ b/lib/l10n/generated/fluxer_localizations_uk.dart
@@ -2568,6 +2568,91 @@ class FluxerLocalizationsUk extends FluxerLocalizations {
   String get typingIndicatorApocalypse => 'Whoa, it\'s a typing apocalypse';
 
   @override
+  String systemJoinGladYoureHere(String username) {
+    return 'Glad you\'re here, $username!';
+  }
+
+  @override
+  String systemJoinWelcomeMakeYourselfAtHome(String username) {
+    return 'Welcome, $username! Make yourself at home.';
+  }
+
+  @override
+  String systemJoinHelloNiceToHaveYouHere(String username) {
+    return 'Hello, $username! Nice to have you here.';
+  }
+
+  @override
+  String systemJoinHelloJumpInWheneverYoureReady(String username) {
+    return 'Hello, $username! Jump in whenever you\'re ready.';
+  }
+
+  @override
+  String systemJoinHeyGreatToSeeYouHere(String username) {
+    return 'Hey $username, great to see you here!';
+  }
+
+  @override
+  String systemJoinHeyThereHopeYouEnjoyYourStay(String username) {
+    return 'Hey there, $username! Hope you enjoy your stay.';
+  }
+
+  @override
+  String systemJoinHeyWelcomeAboard(String username) {
+    return 'Hey, $username, welcome aboard!';
+  }
+
+  @override
+  String systemJoinGladYouMadeIt(String username) {
+    return 'Glad you made it, $username!';
+  }
+
+  @override
+  String systemJoinWelcomeIn(String username) {
+    return 'Welcome in, $username!';
+  }
+
+  @override
+  String systemJoinWelcome(String username) {
+    return 'Welcome, $username!';
+  }
+
+  @override
+  String systemJoinWelcomeWereGladYoureHere(String username) {
+    return 'Welcome, $username! We\'re glad you\'re here.';
+  }
+
+  @override
+  String systemJoinWelcomeHopeYouEnjoyYourTimeHere(String username) {
+    return 'Welcome, $username! Hope you enjoy your time here.';
+  }
+
+  @override
+  String systemJoinWelcomeYourNextConversationStartsHere(String username) {
+    return 'Welcome, $username! Your next conversation starts here.';
+  }
+
+  @override
+  String systemJoinWelcomeWereHappyToHaveYouHere(String username) {
+    return 'Welcome, $username. We\'re happy to have you here.';
+  }
+
+  @override
+  String systemJoinGreatToSeeYouWelcomeIn(String username) {
+    return 'Great to see you, $username! Welcome in.';
+  }
+
+  @override
+  String systemJoinYoureHereGoodToHaveYouWithUs(String username) {
+    return 'You\'re here, $username! Good to have you with us.';
+  }
+
+  @override
+  String systemJoinYouveArrivedLetsGetStarted(String username) {
+    return 'You\'ve arrived, $username! Let\'s get started.';
+  }
+
+  @override
   String get relativeTimeShortNow => 'now';
 
   @override

--- a/lib/l10n/generated/fluxer_localizations_zh.dart
+++ b/lib/l10n/generated/fluxer_localizations_zh.dart
@@ -2568,6 +2568,91 @@ class FluxerLocalizationsZh extends FluxerLocalizations {
   String get typingIndicatorApocalypse => 'Whoa, it\'s a typing apocalypse';
 
   @override
+  String systemJoinGladYoureHere(String username) {
+    return 'Glad you\'re here, $username!';
+  }
+
+  @override
+  String systemJoinWelcomeMakeYourselfAtHome(String username) {
+    return 'Welcome, $username! Make yourself at home.';
+  }
+
+  @override
+  String systemJoinHelloNiceToHaveYouHere(String username) {
+    return 'Hello, $username! Nice to have you here.';
+  }
+
+  @override
+  String systemJoinHelloJumpInWheneverYoureReady(String username) {
+    return 'Hello, $username! Jump in whenever you\'re ready.';
+  }
+
+  @override
+  String systemJoinHeyGreatToSeeYouHere(String username) {
+    return 'Hey $username, great to see you here!';
+  }
+
+  @override
+  String systemJoinHeyThereHopeYouEnjoyYourStay(String username) {
+    return 'Hey there, $username! Hope you enjoy your stay.';
+  }
+
+  @override
+  String systemJoinHeyWelcomeAboard(String username) {
+    return 'Hey, $username, welcome aboard!';
+  }
+
+  @override
+  String systemJoinGladYouMadeIt(String username) {
+    return 'Glad you made it, $username!';
+  }
+
+  @override
+  String systemJoinWelcomeIn(String username) {
+    return 'Welcome in, $username!';
+  }
+
+  @override
+  String systemJoinWelcome(String username) {
+    return 'Welcome, $username!';
+  }
+
+  @override
+  String systemJoinWelcomeWereGladYoureHere(String username) {
+    return 'Welcome, $username! We\'re glad you\'re here.';
+  }
+
+  @override
+  String systemJoinWelcomeHopeYouEnjoyYourTimeHere(String username) {
+    return 'Welcome, $username! Hope you enjoy your time here.';
+  }
+
+  @override
+  String systemJoinWelcomeYourNextConversationStartsHere(String username) {
+    return 'Welcome, $username! Your next conversation starts here.';
+  }
+
+  @override
+  String systemJoinWelcomeWereHappyToHaveYouHere(String username) {
+    return 'Welcome, $username. We\'re happy to have you here.';
+  }
+
+  @override
+  String systemJoinGreatToSeeYouWelcomeIn(String username) {
+    return 'Great to see you, $username! Welcome in.';
+  }
+
+  @override
+  String systemJoinYoureHereGoodToHaveYouWithUs(String username) {
+    return 'You\'re here, $username! Good to have you with us.';
+  }
+
+  @override
+  String systemJoinYouveArrivedLetsGetStarted(String username) {
+    return 'You\'ve arrived, $username! Let\'s get started.';
+  }
+
+  @override
   String get relativeTimeShortNow => 'now';
 
   @override

--- a/test/features/chat/utils/system_message_text_test.dart
+++ b/test/features/chat/utils/system_message_text_test.dart
@@ -1,0 +1,54 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fluxer_app/features/chat/utils/system_message_text.dart';
+import 'package:fluxer_app/l10n/generated/fluxer_localizations_en.dart';
+
+void main() {
+  group('resolveGuildJoinMessage', () {
+    final l10n = FluxerLocalizationsEn();
+
+    test('falls back to the first message for invalid ids', () {
+      expect(
+        resolveGuildJoinMessage(
+          l10n,
+          messageId: 'not-a-snowflake',
+          username: 'Jiralite',
+        ),
+        "Glad you're here, Jiralite!",
+      );
+    });
+
+    test('preserves the username placeholder for rich text rendering', () {
+      final template = resolveGuildJoinMessageTemplate(l10n, messageId: '0');
+
+      expect(template, contains(kGuildJoinMessageUsernamePlaceholder));
+      expect(template, isNot(contains('Jiralite')));
+    });
+
+    test('welcome variants match desktop order', () {
+      expect(
+        <String>[
+          for (final builder in guildJoinMessageBuilders(l10n)) builder('X'),
+        ],
+        <String>[
+          "Glad you're here, X!",
+          'Welcome, X! Make yourself at home.',
+          'Hello, X! Nice to have you here.',
+          "Hello, X! Jump in whenever you're ready.",
+          'Hey X, great to see you here!',
+          'Hey there, X! Hope you enjoy your stay.',
+          'Hey, X, welcome aboard!',
+          'Glad you made it, X!',
+          'Welcome in, X!',
+          'Welcome, X!',
+          "Welcome, X! We're glad you're here.",
+          'Welcome, X! Hope you enjoy your time here.',
+          'Welcome, X! Your next conversation starts here.',
+          "Welcome, X. We're happy to have you here.",
+          'Great to see you, X! Welcome in.',
+          "You're here, X! Good to have you with us.",
+          "You've arrived, X! Let's get started.",
+        ],
+      );
+    });
+  });
+}


### PR DESCRIPTION
# What this PR solves/adds

Strings, localisation descriptions, and the method to generate the system join messages are all taken from desktop.

I saw 16dd987357e275fe4bb76abe4f492848b8f3a36a added message types that were not being used, so I replaced the magic numbers when modifying the logic of `messageTypeUserJoin`.

Also matched the phosphorus icon and colour.

Resolves #339.

<details><summary>Evidence</summary>
<img width="1110" height="980" alt="image" src="https://github.com/user-attachments/assets/03fbc069-57c7-4060-9238-c6f6932c4682" />
</details> 

## PR type

- [ ] Feature
- [x] Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Feature requirements

- GitHub Discussion link: N/A
- Visual proof (screenshot or video): N/A

## Validation

- [x] I explained what this PR solves or adds.
- [x] I verified the changes locally.
- [x] I completed all required feature items, or marked them as `N/A` if not applicable.

## Release Notes

- Fixed system join messages parity with desktop
