### PR TITLE
fix: support role colours in system messages

### DIFF
--- a/lib/features/chat/presentation/widgets/messages/message_list.dart
+++ b/lib/features/chat/presentation/widgets/messages/message_list.dart
@@ -765,7 +765,11 @@ class _MessageListState extends ConsumerState<MessageList> {
         message: message,
         isNewDay: isNewDay,
         visualUnreadId: visualUnreadId,
-        child: SystemMessage(key: ValueKey(message.id), message: message),
+        child: SystemMessage(
+          key: ValueKey(message.id),
+          message: message,
+          guildId: guildId,
+        ),
       );
     }
     final bool isGrouped = !isNewDay && _shouldGroup(message, previousMessage);

--- a/lib/features/chat/presentation/widgets/messages/system_message.dart
+++ b/lib/features/chat/presentation/widgets/messages/system_message.dart
@@ -1,27 +1,38 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:fluxer_app/core/theme/fluxer_theme_extension.dart';
 import 'package:fluxer_app/features/chat/domain/message.dart';
 import 'package:fluxer_app/features/chat/utils/system_message_text.dart';
 import 'package:fluxer_app/l10n/generated/fluxer_localizations.dart';
+import 'package:fluxer_app/shared/providers/member_role_color.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
 
 const Color _kGuildJoinIconColor = Color(0xFF22C55E);
 
 /// Renders a system message as a single row with an icon,
 /// bold author name, descriptive text, and timestamp.
-class SystemMessage extends StatelessWidget {
+class SystemMessage extends ConsumerWidget {
   final Message message;
+  final String? guildId;
 
-  const SystemMessage({required this.message, super.key});
+  const SystemMessage({required this.message, this.guildId, super.key});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final String? resolvedGuildId = guildId;
+    final Color? authorRoleColor = resolvedGuildId == null
+        ? null
+        : ref
+              .watch(
+                memberRoleColorProvider((message.authorId, resolvedGuildId)),
+              )
+              .value;
     final textStyle = TextStyle(
       color: context.colors.textTertiaryMuted,
       fontSize: 14,
     );
     final usernameStyle = TextStyle(
-      color: context.colors.textChat,
+      color: authorRoleColor ?? context.colors.textChat,
       fontWeight: FontWeight.bold,
       fontSize: 14,
     );

--- a/test/features/chat/presentation/widgets/messages/system_message_test.dart
+++ b/test/features/chat/presentation/widgets/messages/system_message_test.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fluxer_app/core/theme/themes/dark.dart';
+import 'package:fluxer_app/features/chat/domain/message.dart';
+import 'package:fluxer_app/features/chat/presentation/widgets/messages/system_message.dart';
+import 'package:fluxer_app/shared/providers/member_role_color.dart';
+
+void main() {
+  testWidgets('colors the system-message author name with the role color', (
+    tester,
+  ) async {
+    const Color roleColor = Color(0xFF4641D9);
+    final message = Message(
+      id: '1',
+      channelId: 'c1',
+      authorId: 'u1',
+      authorName: 'Jiralite',
+      content: '',
+      timestamp: DateTime(2026),
+      type: messageTypeChannelPinnedMessage,
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          memberRoleColorProvider(('u1', 'g1')).overrideWith((ref) => roleColor),
+        ],
+        child: MaterialApp(
+          theme: ThemeData(extensions: <ThemeExtension>[buildDarkColorTheme()]),
+          home: Scaffold(body: SystemMessage(message: message, guildId: 'g1')),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final RichText line = tester.widget(
+      find.byWidgetPredicate(
+        (w) => w is RichText && w.text.toPlainText().startsWith('Jiralite'),
+      ),
+    );
+    final TextSpan username = (line.text as TextSpan).children!.first as TextSpan;
+    expect(username.style?.color, roleColor);
+  });
+}


### PR DESCRIPTION
# What this PR solves/adds

Resolves #341.

<details><summary>Evidence</summary>
<img width="1116" height="984" alt="image" src="https://github.com/user-attachments/assets/d000c859-2d2a-41eb-9c12-5a32703d2a1c" />

<img width="201" height="437" alt="Simulator Screenshot - iPhone 17 Pro - 2026-06-18 at 20 33 39" src="https://github.com/user-attachments/assets/b991cae1-e008-47cc-bb19-a7390ea4fb94" />

</details> 

## PR type

- [ ] Feature
- [x] Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Feature requirements

- GitHub Discussion link: N/A
- Visual proof (screenshot or video): N/A

## Validation

- [x] I explained what this PR solves or adds.
- [x] I verified the changes locally.
- [x] I completed all required feature items, or marked them as `N/A` if not applicable.

## Release Notes

- Fixed system messages not showing role colours
