### PR TITLE
fix(permission): remove existing implementation of `1 << 54` permission

### DIFF
--- a/lib/core/permissions/permission.dart
+++ b/lib/core/permissions/permission.dart
@@ -35,7 +35,7 @@ enum Permission {
   pinMessages(1 << 51),
   bypassSlowmode(1 << 52),
   updateRtcRegion(1 << 53),
-  useTextInVoice(1 << 54);
+  viewChannelMembers(1 << 54);
 
   final int value;
   const Permission(this.value);

--- a/lib/features/chat/providers/channel/channel_message_permissions_provider.dart
+++ b/lib/features/chat/providers/channel/channel_message_permissions_provider.dart
@@ -82,13 +82,9 @@ ChannelMessagePermissions channelMessagePermissionsFromBits({
   required int bits,
   required ChannelType channelType,
 }) {
-  final bool canSendMessages =
-      hasPermission(bits, Permission.sendMessages) ||
-      (channelType == ChannelType.voice &&
-          hasPermission(bits, Permission.useTextInVoice));
   return ChannelMessagePermissions(
     isResolved: true,
-    canSendMessages: canSendMessages,
+    canSendMessages: hasPermission(bits, Permission.sendMessages),
     canAttachFiles: hasPermission(bits, Permission.attachFiles),
     canEmbedLinks: hasPermission(bits, Permission.embedLinks),
     canUseExternalEmojis: hasPermission(bits, Permission.useExternalEmojis),

--- a/lib/features/chat/providers/core/chat_view_model.dart
+++ b/lib/features/chat/providers/core/chat_view_model.dart
@@ -1679,14 +1679,10 @@ class ChatViewModel extends _$ChatViewModel {
             channelId: channelId,
           );
       if (permissionOutcome.shouldCache) {
-        final bool canSendMessages =
-            hasPermission(permissionOutcome.value, Permission.sendMessages) ||
-            (channelRow != null &&
-                channelTypeFromInt(channelRow.type) == ChannelType.voice &&
-                hasPermission(
-                  permissionOutcome.value,
-                  Permission.useTextInVoice,
-                ));
+        final bool canSendMessages = hasPermission(
+          permissionOutcome.value,
+          Permission.sendMessages,
+        );
         if (!canSendMessages) {
           talker.debug(
             '[ChatViewModel] send blocked: no_permission channelId=$channelId',

--- a/lib/features/chat/providers/messages/forward_destinations_provider.dart
+++ b/lib/features/chat/providers/messages/forward_destinations_provider.dart
@@ -241,9 +241,7 @@ ForwardDestinationDisable _resolveDisable({
   required bool hasEmbeds,
   required bool hasAttachments,
 }) {
-  final bool canSend =
-      hasPermission(bits, Permission.sendMessages) ||
-      (isVoice && hasPermission(bits, Permission.useTextInVoice));
+  final bool canSend = hasPermission(bits, Permission.sendMessages);
   if (!canSend) {
     return ForwardDestinationDisable.noSendPermission;
   }


### PR DESCRIPTION
# What this PR solves/adds

`1 << 54` is `VIEW_CHANNEL_MEMBERS`. There is no such permission that allows for using text-in-voice.

See the list of permissions:

https://github.com/fluxerapp/fluxer/blob/fa3e8525755dae087c03ceaf83b814cbe46c7228/packages/constants/src/ChannelConstants.ts#L147-L185

Actual implementation of `VIEW_CHANNEL_MEMBERS` can come at a later date as a feature request, but as it stands, this is incorrectly assuming permissions.

Just to be clear, `VIEW_CHANNEL_MEMBERS` controls who can view the member list–not whether one can send messages in a voice channel.

Resolves #348.

## PR type

- [ ] Feature
- [x] Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Feature requirements

- GitHub Discussion link: N/A
- Visual proof (screenshot or video): N/A

## Validation

- [x] I explained what this PR solves or adds.
- [x] I verified the changes locally.
- [x] I completed all required feature items, or marked them as `N/A` if not applicable.

## Release Notes

- Fixed incorrect implementation of view channel members permission affecting voice channels
