### PR TITLE
fix: implement proper sorting algorithm for channels

### DIFF
--- a/lib/features/channels/domain/channel.dart
+++ b/lib/features/channels/domain/channel.dart
@@ -160,8 +160,8 @@ List<ChannelCategory> groupChannelsIntoCategories(List<Channel> channels) {
     }
   }
 
-  uncategorized.sort((a, b) => a.position.compareTo(b.position));
-  categories.sort((a, b) => a.position.compareTo(b.position));
+  uncategorized.sort(_compareChannelForDisplay);
+  categories.sort(_compareChannelOrdering);
 
   final result = <ChannelCategory>[];
 
@@ -177,9 +177,36 @@ List<ChannelCategory> groupChannelsIntoCategories(List<Channel> channels) {
 
   for (final cat in categories) {
     final children = (parentMap[cat.id] ?? <Channel>[])
-      ..sort((a, b) => a.position.compareTo(b.position));
+      ..sort(_compareChannelForDisplay);
     result.add(ChannelCategory(id: cat.id, name: cat.name, channels: children));
   }
 
   return result;
+}
+
+int _compareChannelOrdering(Channel a, Channel b) {
+  final positionComparison = a.position.compareTo(b.position);
+  return positionComparison != 0 ? positionComparison : a.id.compareTo(b.id);
+}
+
+int _compareChannelForDisplay(Channel a, Channel b) {
+  final aBucket = _channelDisplayBucket(a);
+  final bBucket = _channelDisplayBucket(b);
+  final bucketComparison = aBucket.compareTo(bBucket);
+  return bucketComparison != 0
+      ? bucketComparison
+      : _compareChannelOrdering(a, b);
+}
+
+int _channelDisplayBucket(Channel channel) {
+  switch (channel.type) {
+    case ChannelType.voice:
+    case ChannelType.stage:
+      return 1;
+    case ChannelType.text:
+    case ChannelType.announcement:
+    case ChannelType.link:
+    case ChannelType.category:
+      return 0;
+  }
 }

--- a/test/features/channels/domain/channel_grouping_test.dart
+++ b/test/features/channels/domain/channel_grouping_test.dart
@@ -1,0 +1,91 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fluxer_app/features/channels/domain/channel.dart';
+
+void main() {
+  test('groups text and link channels before voice channels like desktop', () {
+    final categories = groupChannelsIntoCategories([
+      _channel('voice-root', type: ChannelType.voice, position: 1),
+      _channel('text-root', position: 2),
+      _channel('link-root', type: ChannelType.link, position: 3),
+      _channel('cat', type: ChannelType.category, position: 4),
+      _channel(
+        'voice-child',
+        type: ChannelType.voice,
+        position: 5,
+        parentId: 'cat',
+      ),
+      _channel('text-child', position: 6, parentId: 'cat'),
+      _channel(
+        'link-child',
+        type: ChannelType.link,
+        position: 7,
+        parentId: 'cat',
+      ),
+    ]);
+
+    expect(categories, hasLength(2));
+    expect(categories[0].channels.map((channel) => channel.id), [
+      'text-root',
+      'link-root',
+      'voice-root',
+    ]);
+    expect(categories[1].channels.map((channel) => channel.id), [
+      'text-child',
+      'link-child',
+      'voice-child',
+    ]);
+  });
+
+  test('keeps position order within each channel type bucket', () {
+    final categories = groupChannelsIntoCategories([
+      _channel('voice-2', type: ChannelType.voice, position: 4),
+      _channel('text-2', position: 3),
+      _channel('voice-1', type: ChannelType.voice, position: 2),
+      _channel('text-1', position: 1),
+    ]);
+
+    expect(categories.single.channels.map((channel) => channel.id), [
+      'text-1',
+      'text-2',
+      'voice-1',
+      'voice-2',
+    ]);
+  });
+
+  test('breaks position ties by id', () {
+    final categories = groupChannelsIntoCategories([
+      _channel('b', position: 5),
+      _channel('a', position: 5),
+    ]);
+
+    expect(categories.single.channels.map((channel) => channel.id), [
+      'a',
+      'b',
+    ]);
+  });
+
+  test('orders category headers by position', () {
+    final categories = groupChannelsIntoCategories([
+      _channel('cat-b', type: ChannelType.category, position: 2),
+      _channel('cat-a', type: ChannelType.category, position: 1),
+    ]);
+
+    expect(categories.map((category) => category.id), ['cat-a', 'cat-b']);
+  });
+}
+
+Channel _channel(
+  String id, {
+  ChannelType type = ChannelType.text,
+  int position = 0,
+  String? parentId,
+}) {
+  return Channel(
+    id: id,
+    guildId: 'guild',
+    name: id,
+    type: type,
+    position: position,
+    parentId: parentId,
+  );
+}


### PR DESCRIPTION
# What this PR solves/adds

All channel ordering was simply `a.position.compareTo(b.position)`, but channel ordering is more than just that. Categories use this, but other channel types go through buckets, sort, then use snowflake comparison as a fallback. Behaviour now fully matches desktop.

Whilst doing this, noticed there were implementations of channel types that do not exist, but that is out of scope to change here.

Resolves #302.

## PR type

- [ ] Feature
- [x] Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Feature requirements

- GitHub Discussion link: N/A
- Visual proof (screenshot or video): N/A

## Validation

- [x] I explained what this PR solves or adds.
- [x] I verified the changes locally.
- [x] I completed all required feature items, or marked them as `N/A` if not applicable.

## Release Notes

- Fixed parity of channel ordering
