### PR TITLE
fix(channel_jump_link): Parity of jump hosts with desktop

### DIFF
--- a/lib/core/utils/channel_jump_link.dart
+++ b/lib/core/utils/channel_jump_link.dart
@@ -20,10 +20,13 @@ class MessageJumpLink extends ChannelJumpLink {
 }
 
 const Set<String> kOfficialChannelJumpHosts = <String>{
+  'fluxer.com',
   'fluxer.app',
   'canary.fluxer.app',
   'web.fluxer.app',
   'web.canary.fluxer.app',
+  'web.fluxer.com',
+  'web.canary.fluxer.com',
 };
 
 String? channelJumpHostFromBaseUrl(String baseUrl) {

--- a/lib/core/utils/channel_jump_link.dart
+++ b/lib/core/utils/channel_jump_link.dart
@@ -20,12 +20,10 @@ class MessageJumpLink extends ChannelJumpLink {
 }
 
 const Set<String> kOfficialChannelJumpHosts = <String>{
-  'fluxer.com',
   'fluxer.app',
+  'canary.fluxer.app',
   'web.fluxer.app',
   'web.canary.fluxer.app',
-  'web.fluxer.com',
-  'web.canary.fluxer.com',
 };
 
 String? channelJumpHostFromBaseUrl(String baseUrl) {


### PR DESCRIPTION
# What this PR solves/adds

Fully resolves #117 by matching the behaviour from desktop:

https://github.com/fluxerapp/fluxer/blob/fa3e8525755dae087c03ceaf83b814cbe46c7228/fluxer_app/src/features/navigation/utils/DeepLinkUtils.ts#L224

This means removing the *.com URLs (they do not render on desktop). There does not appear to be a way to even generate such message links too.

## PR type

- [ ] Feature
- [x] Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Feature requirements

- GitHub Discussion link: N/A
- Visual proof (screenshot or video): N/A

## Validation

- [x] I explained what this PR solves or adds.
- [x] I verified the changes locally.
- [x] I completed all required feature items, or marked them as `N/A` if not applicable.

## Release Notes

- Matched parity of message link rendering with desktop
