### PR TITLE
fix: remove unreads from badge notification calculation

### DIFF
--- a/lib/core/badge/app_icon_badge.dart
+++ b/lib/core/badge/app_icon_badge.dart
@@ -6,24 +6,12 @@ class AppIconBadgeValue {
   final int count;
 }
 
-const bool kDefaultUnreadMessageBadgeEnabled = true;
-
-/// Plain-unread dot applies to guild channels only.
-/// DM plain unread does not contribute to the dot.
 AppIconBadgeValue computeAppIconBadge({
   required int guildMentionCount,
   required int dmMentionCount,
   required int pendingFriendRequestCount,
-  required bool guildHasPlainUnread,
-  bool unreadMessageBadgeEnabled = kDefaultUnreadMessageBadgeEnabled,
 }) {
   final int mentionTotal = guildMentionCount + dmMentionCount;
   final int totalCount = mentionTotal + pendingFriendRequestCount;
-  if (totalCount > 0) {
-    return AppIconBadgeValue(count: totalCount);
-  }
-  if (guildHasPlainUnread && unreadMessageBadgeEnabled) {
-    return const AppIconBadgeValue(count: 1);
-  }
-  return const AppIconBadgeValue(count: 0);
+  return AppIconBadgeValue(count: totalCount);
 }

--- a/lib/core/badge/app_icon_badge_provider.dart
+++ b/lib/core/badge/app_icon_badge_provider.dart
@@ -89,18 +89,13 @@ class AppIconBadge extends _$AppIconBadge {
     required int pendingFriendRequestCount,
   }) {
     var guildMentionCount = 0;
-    var guildHasPlainUnread = false;
     for (final entry in guildStates.values) {
       guildMentionCount += entry.mentionCount;
-      if (entry.hasPlainUnread) {
-        guildHasPlainUnread = true;
-      }
     }
     return computeAppIconBadge(
       guildMentionCount: guildMentionCount,
       dmMentionCount: _dmMentionCount,
       pendingFriendRequestCount: pendingFriendRequestCount,
-      guildHasPlainUnread: guildHasPlainUnread,
     );
   }
 }

--- a/test/core/badge/app_icon_badge_test.dart
+++ b/test/core/badge/app_icon_badge_test.dart
@@ -9,50 +9,17 @@ void main() {
         guildMentionCount: 3,
         dmMentionCount: 2,
         pendingFriendRequestCount: 1,
-        guildHasPlainUnread: false,
       );
       expect(badge.count, 6);
     });
 
-    test('shows 1 for guild plain unread when no mentions', () {
+    test('clears when there are no counted notifications', () {
       final badge = computeAppIconBadge(
         guildMentionCount: 0,
         dmMentionCount: 0,
         pendingFriendRequestCount: 0,
-        guildHasPlainUnread: true,
-      );
-      expect(badge.count, 1);
-    });
-
-    test('dm plain unread does not show dot badge', () {
-      final badge = computeAppIconBadge(
-        guildMentionCount: 0,
-        dmMentionCount: 0,
-        pendingFriendRequestCount: 0,
-        guildHasPlainUnread: false,
       );
       expect(badge.count, 0);
-    });
-
-    test('clears when no unread and unread badge disabled', () {
-      final badge = computeAppIconBadge(
-        guildMentionCount: 0,
-        dmMentionCount: 0,
-        pendingFriendRequestCount: 0,
-        guildHasPlainUnread: true,
-        unreadMessageBadgeEnabled: false,
-      );
-      expect(badge.count, 0);
-    });
-
-    test('mentions win over plain unread dot', () {
-      final badge = computeAppIconBadge(
-        guildMentionCount: 1,
-        dmMentionCount: 0,
-        pendingFriendRequestCount: 0,
-        guildHasPlainUnread: true,
-      );
-      expect(badge.count, 1);
     });
   });
 


### PR DESCRIPTION
# What this PR solves/adds

Resolves the known issue of a stuck 1 badge notification.

The issue is very simple if you read this:

https://github.com/fluxerapp/flutter_client/blob/c2905759bb23d0b292126cbd4e601a4796306060/lib/core/badge/app_icon_badge.dart#L25-L27

Plain unreads should not contribute to the calculation. That also meant this test was incorrect:

https://github.com/fluxerapp/flutter_client/blob/8103c234c35d004ba9f0167085b1445bb38331c5/test/core/badge/app_icon_badge_test.dart#L17-L25

## PR type

- [ ] Feature
- [x] Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Feature requirements

- GitHub Discussion link: N/A
- Visual proof (screenshot or video): N/A

## Validation

- [x] I explained what this PR solves or adds.
- [x] I verified the changes locally.
- [x] I completed all required feature items, or marked them as `N/A` if not applicable.

## Release Notes

- Fixed stuck badge notification
