### PR TITLE
fix: remove unused channel types

### DIFF
--- a/lib/features/channels/domain/channel.dart
+++ b/lib/features/channels/domain/channel.dart
@@ -1,7 +1,7 @@
 import 'package:drift/drift.dart';
 import 'package:fluxer_app/core/database/fluxer_database.dart' as db;
 
-enum ChannelType { text, voice, announcement, stage, category, link }
+enum ChannelType { text, voice, category, link }
 
 /// Guild channels that support text based unread tracking (text + voice).
 bool isGuildTextBasedChannel(int type) => type == 0 || type == 2;
@@ -17,10 +17,6 @@ ChannelType channelTypeFromInt(int type) {
       return ChannelType.voice;
     case 4:
       return ChannelType.category;
-    case 5:
-      return ChannelType.announcement;
-    case 13:
-      return ChannelType.stage;
     case 998:
       return ChannelType.link;
     default:
@@ -36,10 +32,6 @@ int channelTypeToInt(ChannelType type) {
       return 2;
     case ChannelType.category:
       return 4;
-    case ChannelType.announcement:
-      return 5;
-    case ChannelType.stage:
-      return 13;
     case ChannelType.link:
       return 998;
   }
@@ -201,10 +193,8 @@ int _compareChannelForDisplay(Channel a, Channel b) {
 int _channelDisplayBucket(Channel channel) {
   switch (channel.type) {
     case ChannelType.voice:
-    case ChannelType.stage:
       return 1;
     case ChannelType.text:
-    case ChannelType.announcement:
     case ChannelType.link:
     case ChannelType.category:
       return 0;

--- a/lib/features/channels/domain/channel_access_icon_flags.dart
+++ b/lib/features/channels/domain/channel_access_icon_flags.dart
@@ -30,8 +30,7 @@ bool isChannelEveryonePrivateForIcon({
   final BigInt deny = everyoneOverwrite.deny;
   switch (type) {
     case ChannelType.voice:
-    case ChannelType.stage:
-      // For voice/stage channels, only show a lock overlay when the @everyone
+      // For voice channels, only show a lock overlay when the @everyone
       // entry denies CONNECT AND has no base permissions at all (allow == '0')
       // this indicates a truly private server where the channel is not
       // visible to most users. A role-restricted guild will have an @everyone
@@ -40,7 +39,6 @@ bool isChannelEveryonePrivateForIcon({
       final BigInt connectMask = BigInt.from(Permission.connect.value);
       return (allow == BigInt.zero) && (deny & connectMask) == connectMask;
     case ChannelType.text:
-    case ChannelType.announcement:
     case ChannelType.link:
       final BigInt mask = BigInt.from(Permission.viewChannel.value);
       return (deny & mask) == mask;

--- a/lib/features/channels/presentation/widgets/channel_icon.dart
+++ b/lib/features/channels/presentation/widgets/channel_icon.dart
@@ -34,8 +34,7 @@ ChannelIconAccessOverlay resolveChannelIconAccessOverlay({
   if (channel.nsfw) {
     return ChannelIconAccessOverlay.nsfw;
   }
-  final bool isVoiceLike =
-      channel.type == ChannelType.voice || channel.type == ChannelType.stage;
+  final bool isVoiceLike = channel.type == ChannelType.voice;
   final int? connectBits = canConnectPermissionBits ?? effectivePermissionBits;
   if (isVoiceLike &&
       connectBits != null &&
@@ -44,8 +43,7 @@ ChannelIconAccessOverlay resolveChannelIconAccessOverlay({
   }
   final bool skipEveryonePrivateLockForVoiceIcon =
       isVoiceLike &&
-      (connectBits == null ||
-          hasPermission(connectBits, Permission.connect));
+      (connectBits == null || hasPermission(connectBits, Permission.connect));
   if (!skipEveryonePrivateLockForVoiceIcon &&
       isChannelEveryonePrivateForIcon(
         type: channel.type,
@@ -65,11 +63,7 @@ String? _svgAssetForChannelVisual({
   if (type == ChannelType.category) {
     return null;
   }
-  final bool isTextLike =
-      type == ChannelType.text || type == ChannelType.announcement;
-  final bool isVoiceLike =
-      type == ChannelType.voice || type == ChannelType.stage;
-  if (isTextLike) {
+  if (type == ChannelType.text) {
     return switch (overlay) {
       ChannelIconAccessOverlay.nsfw => _kAssetTextNsfw,
       ChannelIconAccessOverlay.lock => _kAssetTextLocked,
@@ -77,7 +71,7 @@ String? _svgAssetForChannelVisual({
       ChannelIconAccessOverlay.none => _kAssetText,
     };
   }
-  if (isVoiceLike) {
+  if (type == ChannelType.voice) {
     if (e2eeEncrypted) {
       return _kAssetVoiceE2ee;
     }
@@ -157,10 +151,6 @@ class ChannelIcon extends StatelessWidget {
         return PhosphorIconsRegular.hash;
       case ChannelType.voice:
         return PhosphorIconsFill.speakerHigh;
-      case ChannelType.announcement:
-        return PhosphorIconsFill.megaphone;
-      case ChannelType.stage:
-        return PhosphorIconsFill.broadcast;
       case ChannelType.category:
         return PhosphorIconsFill.folder;
       case ChannelType.link:

--- a/lib/features/channels/utils/navigate_to_channel_content.dart
+++ b/lib/features/channels/utils/navigate_to_channel_content.dart
@@ -161,8 +161,7 @@ Future<void> openGuildChannelContent({
   final int? permissionBits =
       effectivePermissionBits ??
       ref.read(effectiveGuildChannelPermissionBitsProvider(channel.id)).value;
-  final int? localConnectBits =
-      channel.type == ChannelType.voice || channel.type == ChannelType.stage
+  final int? localConnectBits = channel.type == ChannelType.voice
       ? ref
             .read(channelLocalGuildChannelPermissionBitsProvider(channel.id))
             .value

--- a/lib/features/chat/presentation/sheets/channel_details_sheet.dart
+++ b/lib/features/chat/presentation/sheets/channel_details_sheet.dart
@@ -3354,8 +3354,6 @@ String? _detailsSubtitle({
     return switch (channel.type) {
       ChannelType.text => 'Text channel',
       ChannelType.voice => 'Voice channel',
-      ChannelType.announcement => 'Announcement channel',
-      ChannelType.stage => 'Stage channel',
       ChannelType.category => 'Category',
       ChannelType.link => 'Linked channel',
     };

--- a/lib/features/chat/providers/messages/forward_destinations_provider.dart
+++ b/lib/features/chat/providers/messages/forward_destinations_provider.dart
@@ -85,7 +85,7 @@ class ForwardDestination {
 /// DMs are returned first (in recency order), then guild channels grouped by
 /// guild name then channel name, so the sheet can build sections by walking
 /// consecutive runs. The source channel is excluded; non-text-based channel
-/// types (category/link/announcement/stage) are filtered out.
+/// types (category/link) are filtered out.
 @riverpod
 Future<List<ForwardDestination>> forwardDestinations(
   Ref ref, {

--- a/lib/features/mature_content/presentation/mature_content_gate_copy.dart
+++ b/lib/features/mature_content/presentation/mature_content_gate_copy.dart
@@ -120,7 +120,7 @@ String _matureBody(
     return l10n.matureCategoryBody;
   }
   return switch (channelType) {
-    ChannelType.voice || ChannelType.stage => l10n.matureVoiceChannelBody,
+    ChannelType.voice => l10n.matureVoiceChannelBody,
     ChannelType.link => l10n.matureLinkChannelBody,
     _ => l10n.matureChannelBody,
   };

--- a/lib/features/quick_switcher/data/quick_switcher_channel_resolver.dart
+++ b/lib/features/quick_switcher/data/quick_switcher_channel_resolver.dart
@@ -68,16 +68,12 @@ class QuickSwitcherChannelResolver {
     Channel channel,
     String? viewContext,
   ) {
-    if (channel.type != ChannelType.text &&
-        channel.type != ChannelType.voice &&
-        channel.type != ChannelType.announcement &&
-        channel.type != ChannelType.stage) {
+    if (channel.type != ChannelType.text && channel.type != ChannelType.voice) {
       return null;
     }
     final Guild? guild = guildsById[channel.guildId];
     final String guildName = guild?.name ?? '';
-    final bool isVoice =
-        channel.type == ChannelType.voice || channel.type == ChannelType.stage;
+    final bool isVoice = channel.type == ChannelType.voice;
     return candidateToQuickSwitcherResult(
       QuickSwitcherChannelCandidate(
         id: channel.id,
@@ -89,8 +85,9 @@ class QuickSwitcherChannelResolver {
         guildIcon: guild?.icon,
         isVoice: isVoice,
         searchValues: <String>[channel.name, guildName, channel.id],
-        sortWeight:
-            dateTimeFromSnowflakeAsLocalOrNow(channel.id).millisecondsSinceEpoch,
+        sortWeight: dateTimeFromSnowflakeAsLocalOrNow(
+          channel.id,
+        ).millisecondsSinceEpoch,
       ),
       l10n,
       viewContext: viewContext,

--- a/lib/features/voice/providers/voice_join_eligibility_provider.dart
+++ b/lib/features/voice/providers/voice_join_eligibility_provider.dart
@@ -20,7 +20,7 @@ bool canJoinGuildVoiceChannelFromBits({
   if (guildId.isEmpty) {
     return true;
   }
-  if (channelType != ChannelType.voice && channelType != ChannelType.stage) {
+  if (channelType != ChannelType.voice) {
     return true;
   }
   if (permissionBits == null) {
@@ -48,8 +48,9 @@ Future<VoiceJoinEligibility> voiceJoinEligibility(
   if (channelRow.guildId.isEmpty) {
     return const VoiceJoinEligibility(canJoin: true);
   }
-  final int? permissionBits =
-      ref.watch(channelPermissionCacheProvider)[channelId];
+  final int? permissionBits = ref.watch(
+    channelPermissionCacheProvider,
+  )[channelId];
   final bool canJoin = canJoinGuildVoiceChannelFromBits(
     guildId: channelRow.guildId,
     channelType: channelType,

--- a/test/features/channels/domain/channel_access_icon_flags_test.dart
+++ b/test/features/channels/domain/channel_access_icon_flags_test.dart
@@ -130,24 +130,6 @@ void main() {
       );
     });
 
-    test('stage channel: everyone fully denies CONNECT', () {
-      expect(
-        isChannelEveryonePrivateForIcon(
-          type: ChannelType.stage,
-          guildId: guildId,
-          permissionOverwritesJson: jsonEncode(<Map<String, Object>>[
-            <String, Object>{
-              'id': guildId,
-              'type': 0,
-              'allow': '0',
-              'deny': '1048576',
-            },
-          ]),
-        ),
-        isTrue,
-      );
-    });
-
     test('category ignores overwrites', () {
       expect(
         isChannelEveryonePrivateForIcon(

--- a/test/features/channels/presentation/channel_icon_overlay_test.dart
+++ b/test/features/channels/presentation/channel_icon_overlay_test.dart
@@ -136,18 +136,15 @@ void main() {
       },
     );
 
-    test(
-      'voice noConnect only triggers on voice/stage with denied connect bits',
-      () {
-        final channel = makeVoiceChannel();
-        final int deniedBits = Permission.viewChannel.value;
+    test('voice noConnect triggers with denied connect bits', () {
+      final channel = makeVoiceChannel();
+      final int deniedBits = Permission.viewChannel.value;
 
-        final overlay = resolveChannelIconAccessOverlay(
-          channel: channel,
-          canConnectPermissionBits: deniedBits,
-        );
-        expect(overlay, equals(ChannelIconAccessOverlay.noConnect));
-      },
-    );
+      final overlay = resolveChannelIconAccessOverlay(
+        channel: channel,
+        canConnectPermissionBits: deniedBits,
+      );
+      expect(overlay, equals(ChannelIconAccessOverlay.noConnect));
+    });
   });
 }

--- a/test/features/chat/providers/messages/forward_destinations_provider_test.dart
+++ b/test/features/chat/providers/messages/forward_destinations_provider_test.dart
@@ -92,7 +92,6 @@ Future<FluxerDatabase> _seedDb() async {
   await channel('c_text', _ownedGuild, 0);
   await channel('c_voice', _ownedGuild, 2);
   await channel('c_category', _ownedGuild, 4);
-  await channel('c_announcement', _ownedGuild, 5);
   await channel('c_link', _ownedGuild, 998);
 
   // Other guild: the user has no membership, so sending is blocked.
@@ -194,7 +193,6 @@ void main() {
 
       expect(byId.containsKey('c_source'), isFalse, reason: 'source excluded');
       expect(byId.containsKey('c_category'), isFalse);
-      expect(byId.containsKey('c_announcement'), isFalse);
       expect(byId.containsKey('c_link'), isFalse);
       expect(byId.containsKey('c_text'), isTrue);
       expect(byId.containsKey('c_voice'), isTrue);


### PR DESCRIPTION
# What this PR solves/adds

Fluxer does not have stage channels or announcement channels. With proposed channel types like calendars being talked about, it is theoretically possibly for them to use a number these are occupying, leading to incorrect behaviour down the road.

## PR type

- [ ] Feature
- [x] Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Feature requirements

- GitHub Discussion link: N/A
- Visual proof (screenshot or video): N/A

## Validation

- [x] I explained what this PR solves or adds.
- [x] I verified the changes locally.
- [x] I completed all required feature items, or marked them as `N/A` if not applicable.

## Release Notes

- N/A
