### PR TITLE
fix: ensure login screens are mutually exclusive

### DIFF
--- a/lib/features/auth/providers/login_view_model.dart
+++ b/lib/features/auth/providers/login_view_model.dart
@@ -203,6 +203,9 @@ class LoginViewModel extends _$LoginViewModel {
   void showRegisterScreen() {
     state = state.copyWith(
       showRegister: true,
+      showForgotPassword: false,
+      forgotPasswordEmailSent: false,
+      resetToken: null,
       errorMessage: null,
       fieldErrors: const {},
     );
@@ -339,7 +342,9 @@ class LoginViewModel extends _$LoginViewModel {
   void showForgotPasswordScreen() {
     state = state.copyWith(
       showForgotPassword: true,
+      showRegister: false,
       forgotPasswordEmailSent: false,
+      resetToken: null,
       errorMessage: null,
       fieldErrors: const {},
     );
@@ -358,6 +363,7 @@ class LoginViewModel extends _$LoginViewModel {
     state = state.copyWith(
       resetToken: token,
       showForgotPassword: false,
+      showRegister: false,
       forgotPasswordEmailSent: false,
       errorMessage: null,
       fieldErrors: const {},

--- a/test/features/auth/providers/login_view_model_test.dart
+++ b/test/features/auth/providers/login_view_model_test.dart
@@ -34,7 +34,62 @@ ProviderContainer _containerFor(AuthFailure failure) {
   return container;
 }
 
+ProviderContainer _container() {
+  final container = ProviderContainer();
+  addTearDown(container.dispose);
+  return container;
+}
+
 void main() {
+  test('ensure login screen transitions are mutually exclusive', () {
+    final container = _container();
+    final notifier = container.read(loginViewModelProvider.notifier);
+    final transitions =
+        <
+          ({
+            String name,
+            void Function() enter,
+            bool forgot,
+            bool register,
+            bool reset,
+          })
+        >[
+          (
+            name: 'forgot password',
+            enter: notifier.showForgotPasswordScreen,
+            forgot: true,
+            register: false,
+            reset: false,
+          ),
+          (
+            name: 'register',
+            enter: notifier.showRegisterScreen,
+            forgot: false,
+            register: true,
+            reset: false,
+          ),
+          (
+            name: 'reset password',
+            enter: () => notifier.setResetToken('reset-token'),
+            forgot: false,
+            register: false,
+            reset: true,
+          ),
+        ];
+
+    for (final seed in transitions) {
+      for (final target in transitions) {
+        seed.enter();
+        target.enter();
+
+        final state = container.read(loginViewModelProvider);
+        expect(state.showForgotPassword, target.forgot, reason: target.name);
+        expect(state.showRegister, target.register, reason: target.name);
+        expect(state.resetToken != null, target.reset, reason: target.name);
+      }
+    }
+  });
+
   test('an invalid-credentials failure shows a single general error', () async {
     final container = _containerFor(
       const AuthFailure(


### PR DESCRIPTION
# What this PR solves/adds

Resolves #367 by making sure each login authentication screen is mutually exclusive. Maybe an `enum` in the future?

<details><summary>Evidence</summary>

https://github.com/user-attachments/assets/76479cdb-f281-4cc7-8aa5-dfaa24cd9551

</details> 

## PR type

- [ ] Feature
- [x] Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Feature requirements

- GitHub Discussion link: N/A
- Visual proof (screenshot or video): N/A

## Validation

- [x] I explained what this PR solves or adds.
- [x] I verified the changes locally.
- [x] I completed all required feature items, or marked them as `N/A` if not applicable.

## Release Notes

- Fixed non-functional register button in forget password screen
