### PR TITLE
feat: tappable badges

### DIFF
--- a/lib/features/profile/presentation/widgets/user_profile_badges.dart
+++ b/lib/features/profile/presentation/widgets/user_profile_badges.dart
@@ -1,8 +1,13 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:fluxer_app/core/theme/fluxer_color_theme.dart';
 import 'package:fluxer_app/core/theme/fluxer_theme_extension.dart';
+import 'package:fluxer_app/features/ui/tappable/fluxer_tappable.dart';
+import 'package:fluxer_app/features/ui/toast/fluxer_toast.dart';
+import 'package:fluxer_app/features/ui/toast/toast_provider.dart';
 import 'package:fluxer_app/l10n/generated/fluxer_localizations.dart';
+import 'package:intl/intl.dart';
 
 const int _kFlagStaff = 1 << 0;
 const int _kFlagCtp = 1 << 1;
@@ -16,6 +21,54 @@ const String _kCtpBadgeAsset = 'assets/images/badges/ctp.svg';
 const String _kPartnerBadgeAsset = 'assets/images/badges/partner.svg';
 const String _kBugHunterBadgeAsset = 'assets/images/badges/bug-hunter.svg';
 const String _kPlutoniumBadgeAsset = 'assets/images/badges/plutonium.svg';
+
+const _kFlagBadgeSpecs = <_FlagBadgeSpec>[
+  _FlagBadgeSpec(
+    flag: _kFlagStaff,
+    asset: _kStaffBadgeAsset,
+    tooltip: _FlagBadgeTooltip.staff,
+  ),
+  _FlagBadgeSpec(
+    flag: _kFlagCtp,
+    asset: _kCtpBadgeAsset,
+    tooltip: _FlagBadgeTooltip.ctp,
+  ),
+  _FlagBadgeSpec(
+    flag: _kFlagPartner,
+    asset: _kPartnerBadgeAsset,
+    tooltip: _FlagBadgeTooltip.partner,
+  ),
+  _FlagBadgeSpec(
+    flag: _kFlagBugHunter,
+    asset: _kBugHunterBadgeAsset,
+    tooltip: _FlagBadgeTooltip.bugHunter,
+  ),
+];
+
+enum _FlagBadgeTooltip { staff, ctp, partner, bugHunter }
+
+class _FlagBadgeSpec {
+  const _FlagBadgeSpec({
+    required this.flag,
+    required this.asset,
+    required this.tooltip,
+  });
+
+  final int flag;
+  final String asset;
+  final _FlagBadgeTooltip tooltip;
+
+  bool isSet(int flags) => flags & flag != 0;
+
+  String tooltipText(FluxerLocalizations l10n) {
+    return switch (tooltip) {
+      _FlagBadgeTooltip.staff => l10n.userProfileStaffBadgeTooltip,
+      _FlagBadgeTooltip.ctp => l10n.userProfileCtpBadgeTooltip,
+      _FlagBadgeTooltip.partner => l10n.userProfilePartnerBadgeTooltip,
+      _FlagBadgeTooltip.bugHunter => l10n.userProfileBugHunterBadgeTooltip,
+    };
+  }
+}
 
 TextStyle visionaryIdBadgeTextStyle(
   FluxerColorTheme colors,
@@ -36,18 +89,49 @@ class UserProfileBadges extends StatelessWidget {
   const UserProfileBadges({
     required this.flags,
     this.hasPlutonium = false,
+    this.isLifetimePlutonium = false,
+    this.premiumSince,
     this.premiumLifetimeSequence,
     super.key,
   });
 
   final int flags;
   final bool hasPlutonium;
+  final bool isLifetimePlutonium;
+  final String? premiumSince;
   final int? premiumLifetimeSequence;
 
-  Widget _buildBadge({required String asset, required String tooltip}) {
-    return Tooltip(
-      message: tooltip,
-      preferBelow: false,
+  static bool hasBadges({required int flags, bool hasPlutonium = false}) {
+    return hasPlutonium || _kFlagBadgeSpecs.any((badge) => badge.isSet(flags));
+  }
+
+  Widget _wrapBadge(
+    BuildContext context, {
+    required String tooltip,
+    required Widget child,
+  }) {
+    final content = FluxerTappable(
+      onTap: () => ProviderScope.containerOf(
+        context,
+        listen: false,
+      ).read(toastProvider.notifier).show(FluxerToast(message: tooltip)),
+      button: true,
+      semanticLabel: tooltip,
+      excludeChildSemantics: true,
+      builder: (context, states) => child,
+    );
+
+    return Tooltip(message: tooltip, preferBelow: false, child: content);
+  }
+
+  Widget _buildBadge(
+    BuildContext context, {
+    required String asset,
+    required String tooltip,
+  }) {
+    return _wrapBadge(
+      context,
+      tooltip: tooltip,
       child: SvgPicture.asset(
         asset,
         width: _kBadgeSize,
@@ -57,57 +141,66 @@ class UserProfileBadges extends StatelessWidget {
     );
   }
 
+  String _premiumTooltip(FluxerLocalizations l10n) {
+    final String? since = _formatPremiumSince(premiumSince);
+    if (isLifetimePlutonium) {
+      return since == null
+          ? l10n.userProfileVisionaryBadgeTooltip
+          : l10n.userProfileVisionaryBadgeSinceTooltip(since);
+    }
+    return since == null
+        ? l10n.userProfilePlutoniumBadgeTooltip
+        : l10n.userProfilePlutoniumSubscriberSinceTooltip(since);
+  }
+
+  static String? _formatPremiumSince(String? premiumSince) {
+    if (premiumSince == null) {
+      return null;
+    }
+    final DateTime? date = DateTime.tryParse(premiumSince);
+    if (date == null) {
+      return null;
+    }
+    return DateFormat.yMMMd().format(date.toLocal());
+  }
+
   @override
   Widget build(BuildContext context) {
     final FluxerLocalizations l10n = FluxerLocalizations.of(context);
     final List<Widget> children = <Widget>[];
-    if (flags & _kFlagStaff != 0) {
+
+    for (final badge in _kFlagBadgeSpecs) {
+      if (!badge.isSet(flags)) {
+        continue;
+      }
       children.add(
         _buildBadge(
-          asset: _kStaffBadgeAsset,
-          tooltip: l10n.userProfileStaffBadgeTooltip,
+          context,
+          asset: badge.asset,
+          tooltip: badge.tooltipText(l10n),
         ),
       );
     }
-    if (flags & _kFlagCtp != 0) {
-      children.add(
-        _buildBadge(
-          asset: _kCtpBadgeAsset,
-          tooltip: l10n.userProfileCtpBadgeTooltip,
-        ),
-      );
-    }
-    if (flags & _kFlagPartner != 0) {
-      children.add(
-        _buildBadge(
-          asset: _kPartnerBadgeAsset,
-          tooltip: l10n.userProfilePartnerBadgeTooltip,
-        ),
-      );
-    }
-    if (flags & _kFlagBugHunter != 0) {
-      children.add(
-        _buildBadge(
-          asset: _kBugHunterBadgeAsset,
-          tooltip: l10n.userProfileBugHunterBadgeTooltip,
-        ),
-      );
-    }
+
     if (hasPlutonium) {
       children.add(
         _buildBadge(
+          context,
           asset: _kPlutoniumBadgeAsset,
-          tooltip: l10n.userProfilePlutoniumBadgeTooltip,
+          tooltip: _premiumTooltip(l10n),
         ),
       );
     }
     if (hasPlutonium && premiumLifetimeSequence != null) {
       final FluxerColorTheme colors = context.colors;
       final Brightness brightness = Theme.of(context).brightness;
+      final tooltip = l10n.userProfileVisionaryIdTooltip(
+        premiumLifetimeSequence!,
+      );
       children.add(
-        Tooltip(
-          message: l10n.userProfileVisionaryIdTooltip(premiumLifetimeSequence!),
-          preferBelow: false,
+        _wrapBadge(
+          context,
+          tooltip: tooltip,
           child: Text(
             '#$premiumLifetimeSequence',
             style: visionaryIdBadgeTextStyle(colors, brightness),

--- a/lib/features/profile/presentation/widgets/user_profile_header.dart
+++ b/lib/features/profile/presentation/widgets/user_profile_header.dart
@@ -12,6 +12,8 @@ class UserProfileHeader extends StatelessWidget {
     required this.flags,
     required this.hasPlutonium,
     required this.customStatus,
+    this.isLifetimePlutonium = false,
+    this.premiumSince,
     this.pronouns,
     this.premiumLifetimeSequence,
     this.showUsername = true,
@@ -25,6 +27,8 @@ class UserProfileHeader extends StatelessWidget {
   final int flags;
   final bool hasPlutonium;
   final String? customStatus;
+  final bool isLifetimePlutonium;
+  final String? premiumSince;
   final String? pronouns;
   final int? premiumLifetimeSequence;
   final bool showUsername;
@@ -87,6 +91,8 @@ class UserProfileHeader extends StatelessWidget {
               UserProfileBadges(
                 flags: flags,
                 hasPlutonium: hasPlutonium,
+                isLifetimePlutonium: isLifetimePlutonium,
+                premiumSince: premiumSince,
                 premiumLifetimeSequence: premiumLifetimeSequence,
               ),
             ],

--- a/lib/features/profile/presentation/widgets/user_profile_view.dart
+++ b/lib/features/profile/presentation/widgets/user_profile_view.dart
@@ -305,6 +305,8 @@ class _UserProfileViewState extends ConsumerState<UserProfileView> {
     required List<MemberRole> memberRoles,
     required int flags,
     required bool hasPlutonium,
+    required bool isLifetimePlutonium,
+    required String? premiumSince,
     required int? premiumLifetimeSequence,
     required List<UserPartialResponse> mutualFriends,
     required List<MutualGuildResponse> mutualCommunities,
@@ -513,6 +515,8 @@ class _UserProfileViewState extends ConsumerState<UserProfileView> {
                   displayName: displayName,
                   flags: flags,
                   hasPlutonium: hasPlutonium,
+                  isLifetimePlutonium: isLifetimePlutonium,
+                  premiumSince: premiumSince,
                   premiumLifetimeSequence: premiumLifetimeSequence,
                   customStatus: customStatus,
                   pronouns: pronouns,
@@ -621,6 +625,8 @@ class _UserProfileViewState extends ConsumerState<UserProfileView> {
       memberRoles: const <MemberRole>[],
       flags: 0,
       hasPlutonium: false,
+      isLifetimePlutonium: false,
+      premiumSince: null,
       premiumLifetimeSequence: null,
       mutualFriends: const <UserPartialResponse>[],
       mutualCommunities: const <MutualGuildResponse>[],
@@ -710,6 +716,8 @@ class _UserProfileViewState extends ConsumerState<UserProfileView> {
             hasPlutonium:
                 settingsState.isPremium &&
                 !settingsState.effectivePremiumBadgeHidden,
+            isLifetimePlutonium: settingsState.hasLifetimePremium,
+            premiumSince: settingsState.premiumSince,
             premiumLifetimeSequence:
                 settingsState.hasLifetimePremium &&
                     !settingsState.effectivePremiumBadgeMasked &&
@@ -884,6 +892,9 @@ class _UserProfileViewState extends ConsumerState<UserProfileView> {
           hasPlutonium:
               response.premiumType != null &&
               response.premiumType != UserPremiumTypes.none,
+          isLifetimePlutonium:
+              response.premiumType == UserPremiumTypes.lifetime,
+          premiumSince: response.premiumSince,
           premiumLifetimeSequence:
               response.premiumType == UserPremiumTypes.lifetime
               ? response.premiumLifetimeSequence

--- a/lib/features/settings/presentation/widgets/profile_preview_card.dart
+++ b/lib/features/settings/presentation/widgets/profile_preview_card.dart
@@ -3,7 +3,6 @@ import 'dart:typed_data';
 
 import 'package:cached_network_image_ce/cached_network_image.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_svg/flutter_svg.dart';
 import 'package:fluxer_app/core/theme/fluxer_color_theme.dart';
 import 'package:fluxer_app/core/theme/fluxer_layout_theme.dart';
 import 'package:fluxer_app/core/theme/fluxer_text_theme.dart';
@@ -28,11 +27,6 @@ const int _kDefaultAccentColor = 0x4641D9;
 const double _kBannerAspectRatio = 17 / 6;
 const double _kContentPaddingH = 16;
 const double _kAvatarLeft = 10;
-const double _kBadgeSize = 20;
-
-const int _kFlagStaff = 1 << 0;
-const int _kFlagPartner = 1 << 2;
-const int _kFlagBugHunter = 1 << 3;
 
 class ProfilePreviewCard extends StatefulWidget {
   const ProfilePreviewCard({required this.state, super.key});
@@ -173,7 +167,6 @@ class _ProfilePreviewCardState extends State<ProfilePreviewCard> {
                   textStyles,
                   layout,
                   l10n,
-                  Theme.of(context).brightness,
                 ),
               ),
             ),
@@ -190,10 +183,20 @@ class _ProfilePreviewCardState extends State<ProfilePreviewCard> {
     FluxerTextTheme textStyles,
     FluxerLayoutTheme layout,
     FluxerLocalizations l10n,
-    Brightness brightness,
   ) {
     final effectiveBio = _effectiveBio();
-    final badges = _collectBadges(s, colors, brightness);
+    final showPremiumBadge = s.isPremium && !s.effectivePremiumBadgeHidden;
+    final hasBadges = UserProfileBadges.hasBadges(
+      flags: s.publicFlags,
+      hasPlutonium: showPremiumBadge,
+    );
+    final premiumLifetimeSequence =
+        showPremiumBadge &&
+            s.hasLifetimePremium &&
+            !s.effectivePremiumBadgeMasked &&
+            !s.effectivePremiumBadgeSequenceHidden
+        ? s.premiumLifetimeSequence
+        : null;
 
     return LayoutBuilder(
       builder: (context, constraints) {
@@ -253,7 +256,7 @@ class _ProfilePreviewCardState extends State<ProfilePreviewCard> {
                 ),
               ],
             ),
-            if (badges.isNotEmpty)
+            if (hasBadges)
               Positioned(
                 top: bannerH + 10,
                 right: 10,
@@ -264,7 +267,13 @@ class _ProfilePreviewCardState extends State<ProfilePreviewCard> {
                   ),
                   child: Padding(
                     padding: const EdgeInsets.all(4),
-                    child: Wrap(spacing: 4, runSpacing: 4, children: badges),
+                    child: UserProfileBadges(
+                      flags: s.publicFlags,
+                      hasPlutonium: showPremiumBadge,
+                      isLifetimePlutonium: s.hasLifetimePremium,
+                      premiumSince: s.premiumSince,
+                      premiumLifetimeSequence: premiumLifetimeSequence,
+                    ),
                   ),
                 ),
               ),
@@ -358,69 +367,6 @@ class _ProfilePreviewCardState extends State<ProfilePreviewCard> {
         ],
       ),
     );
-  }
-
-  List<Widget> _collectBadges(
-    UserSettingsViewState s,
-    FluxerColorTheme colors,
-    Brightness brightness,
-  ) {
-    final badges = <Widget>[];
-    final flags = s.publicFlags;
-
-    if (flags & _kFlagStaff != 0) {
-      badges.add(
-        SvgPicture.asset(
-          'assets/images/badges/staff.svg',
-          width: _kBadgeSize,
-          height: _kBadgeSize,
-        ),
-      );
-    }
-    if (flags & _kFlagPartner != 0) {
-      badges.add(
-        SvgPicture.asset(
-          'assets/images/badges/partner.svg',
-          width: _kBadgeSize,
-          height: _kBadgeSize,
-        ),
-      );
-    }
-    if (flags & _kFlagBugHunter != 0) {
-      badges.add(
-        SvgPicture.asset(
-          'assets/images/badges/bug-hunter.svg',
-          width: _kBadgeSize,
-          height: _kBadgeSize,
-        ),
-      );
-    }
-
-    final showPremiumBadge = s.isPremium && !s.effectivePremiumBadgeHidden;
-    if (showPremiumBadge) {
-      badges.add(
-        SvgPicture.asset(
-          'assets/images/badges/plutonium.svg',
-          width: _kBadgeSize,
-          height: _kBadgeSize,
-        ),
-      );
-    }
-
-    if (showPremiumBadge &&
-        s.hasLifetimePremium &&
-        !s.effectivePremiumBadgeMasked &&
-        !s.effectivePremiumBadgeSequenceHidden &&
-        s.premiumLifetimeSequence != null) {
-      badges.add(
-        Text(
-          '#${s.premiumLifetimeSequence}',
-          style: visionaryIdBadgeTextStyle(colors, brightness),
-        ),
-      );
-    }
-
-    return badges;
   }
 
   Widget _buildUserInfo(

--- a/lib/features/settings/presentation/widgets/user_profile.dart
+++ b/lib/features/settings/presentation/widgets/user_profile.dart
@@ -1139,7 +1139,7 @@ class _UserProfileState extends ConsumerState<UserProfile> {
     if (state.premiumSince != null) {
       final date = DateTime.tryParse(state.premiumSince!);
       if (date != null) {
-        final formatted = DateFormat.yMMMd().format(date);
+        final formatted = DateFormat.yMMMd().format(date.toLocal());
         timestampLabel = l10n.hidePlutoniumPurchaseDateWithDate(formatted);
       }
     }

--- a/lib/features/settings/presentation/widgets/user_security_login.dart
+++ b/lib/features/settings/presentation/widgets/user_security_login.dart
@@ -31,8 +31,6 @@ import 'package:fluxer_app/shared/utils/relative_time.dart';
 import 'package:fluxer_dart/export.dart';
 
 // TODO: Re-enable if needed for WhatsApp replacement eligibility rules.
-// const int _kFlagStaff = 1 << 0;
-// const int _kFlagPartner = 1 << 2;
 const int _kMaxPasskeys = 10;
 
 class UserSecurityLogin extends ConsumerStatefulWidget {

--- a/lib/l10n/fluxer_en.arb
+++ b/lib/l10n/fluxer_en.arb
@@ -2792,27 +2792,71 @@
   },
   "userProfileStaffBadgeTooltip": "Fluxer Staff",
   "@userProfileStaffBadgeTooltip": {
-    "description": "Tooltip and semantic label for the staff badge on a user profile."
+    "description": "Short badge title in the user profile badges popout. English locales use Title Case for official badge titles; other locales should use natural local capitalization."
   },
   "userProfileCtpBadgeTooltip": "Fluxer Community Team",
   "@userProfileCtpBadgeTooltip": {
-    "description": "Tooltip and semantic label for the community team badge on a user profile."
+    "description": "Short badge title in the user profile badges popout. English locales use Title Case for official badge titles; other locales should use natural local capitalization."
   },
   "userProfilePartnerBadgeTooltip": "Fluxer Partner",
   "@userProfilePartnerBadgeTooltip": {
-    "description": "Tooltip and semantic label for the partner badge on a user profile."
+    "description": "Short badge title in the user profile badges popout. English locales use Title Case for official badge titles; other locales should use natural local capitalization."
   },
   "userProfileBugHunterBadgeTooltip": "Fluxer Bug Hunter",
   "@userProfileBugHunterBadgeTooltip": {
-    "description": "Tooltip and semantic label for the bug hunter badge on a user profile."
+    "description": "Short badge title in the user profile badges popout. English locales use Title Case for official badge titles; other locales should use natural local capitalization."
   },
   "userProfilePlutoniumBadgeTooltip": "Fluxer Plutonium",
   "@userProfilePlutoniumBadgeTooltip": {
-    "description": "Tooltip and semantic label for the Plutonium badge on a user profile."
+    "description": "Short badge title in the user profile badges popout. English locales use Title Case for official badge titles; other locales should use natural local capitalization."
+  },
+  "userProfilePlutoniumSubscriberSinceTooltip": "Fluxer Plutonium subscriber since {date}",
+  "@userProfilePlutoniumSubscriberSinceTooltip": {
+    "description": "Badge label with a date in the user profile badges popout. Preserve {date}; it is inserted by code. In English, keep \"subscriber since\" lowercase. Other locales should use natural local capitalization.",
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  },
+  "userProfileVisionaryBadgeTooltip": "Fluxer Visionary",
+  "@userProfileVisionaryBadgeTooltip": {
+    "description": "Short badge title in the user profile badges popout. English locales use Title Case for official badge titles; other locales should use natural local capitalization."
+  },
+  "userProfileVisionaryBadgeSinceTooltip": "Fluxer Visionary since {date}",
+  "@userProfileVisionaryBadgeSinceTooltip": {
+    "description": "Badge title with a date in the user profile badges popout. Preserve {date}; it is inserted by code. English locales use Title Case for the badge title part; other locales should use natural local capitalization.",
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  },
+  "userProfilePlutoniumSubscriberSinceTooltip": "Fluxer Plutonium subscriber since {date}",
+  "@userProfilePlutoniumSubscriberSinceTooltip": {
+    "description": "Tooltip and semantic label for the Plutonium badge on a user profile, including the date the user began subscribing.",
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  },
+  "userProfileVisionaryBadgeTooltip": "Fluxer Visionary",
+  "@userProfileVisionaryBadgeTooltip": {
+    "description": "Tooltip and semantic label for the lifetime Plutonium (Visionary) badge on a user profile."
+  },
+  "userProfileVisionaryBadgeSinceTooltip": "Fluxer Visionary since {date}",
+  "@userProfileVisionaryBadgeSinceTooltip": {
+    "description": "Tooltip and semantic label for the lifetime Plutonium (Visionary) badge on a user profile, including the date the user became a Visionary.",
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
   },
   "userProfileVisionaryIdTooltip": "Visionary ID #{sequence}",
   "@userProfileVisionaryIdTooltip": {
-    "description": "Tooltip for the Visionary ID number shown next to the premium badge on a user profile.",
+    "description": "Short label in the user profile badges popout. Keep it concise. Preserve {sequence}; it is inserted by code.",
     "placeholders": {
       "sequence": {
         "type": "int"

--- a/lib/l10n/generated/fluxer_localizations.dart
+++ b/lib/l10n/generated/fluxer_localizations.dart
@@ -4023,37 +4023,55 @@ abstract class FluxerLocalizations {
   /// **'Edit Profile'**
   String get userProfileEditProfile;
 
-  /// Tooltip and semantic label for the staff badge on a user profile.
+  /// Short badge title in the user profile badges popout. English locales use Title Case for official badge titles; other locales should use natural local capitalization.
   ///
   /// In en, this message translates to:
   /// **'Fluxer Staff'**
   String get userProfileStaffBadgeTooltip;
 
-  /// Tooltip and semantic label for the community team badge on a user profile.
+  /// Short badge title in the user profile badges popout. English locales use Title Case for official badge titles; other locales should use natural local capitalization.
   ///
   /// In en, this message translates to:
   /// **'Fluxer Community Team'**
   String get userProfileCtpBadgeTooltip;
 
-  /// Tooltip and semantic label for the partner badge on a user profile.
+  /// Short badge title in the user profile badges popout. English locales use Title Case for official badge titles; other locales should use natural local capitalization.
   ///
   /// In en, this message translates to:
   /// **'Fluxer Partner'**
   String get userProfilePartnerBadgeTooltip;
 
-  /// Tooltip and semantic label for the bug hunter badge on a user profile.
+  /// Short badge title in the user profile badges popout. English locales use Title Case for official badge titles; other locales should use natural local capitalization.
   ///
   /// In en, this message translates to:
   /// **'Fluxer Bug Hunter'**
   String get userProfileBugHunterBadgeTooltip;
 
-  /// Tooltip and semantic label for the Plutonium badge on a user profile.
+  /// Short badge title in the user profile badges popout. English locales use Title Case for official badge titles; other locales should use natural local capitalization.
   ///
   /// In en, this message translates to:
   /// **'Fluxer Plutonium'**
   String get userProfilePlutoniumBadgeTooltip;
 
-  /// Tooltip for the Visionary ID number shown next to the premium badge on a user profile.
+  /// Badge label with a date in the user profile badges popout. Preserve {date}; it is inserted by code. In English, keep "subscriber since" lowercase. Other locales should use natural local capitalization.
+  ///
+  /// In en, this message translates to:
+  /// **'Fluxer Plutonium subscriber since {date}'**
+  String userProfilePlutoniumSubscriberSinceTooltip(String date);
+
+  /// Short badge title in the user profile badges popout. English locales use Title Case for official badge titles; other locales should use natural local capitalization.
+  ///
+  /// In en, this message translates to:
+  /// **'Fluxer Visionary'**
+  String get userProfileVisionaryBadgeTooltip;
+
+  /// Badge title with a date in the user profile badges popout. Preserve {date}; it is inserted by code. English locales use Title Case for the badge title part; other locales should use natural local capitalization.
+  ///
+  /// In en, this message translates to:
+  /// **'Fluxer Visionary since {date}'**
+  String userProfileVisionaryBadgeSinceTooltip(String date);
+
+  /// Short label in the user profile badges popout. Keep it concise. Preserve {sequence}; it is inserted by code.
   ///
   /// In en, this message translates to:
   /// **'Visionary ID #{sequence}'**

--- a/lib/l10n/generated/fluxer_localizations_af.dart
+++ b/lib/l10n/generated/fluxer_localizations_af.dart
@@ -2235,6 +2235,19 @@ class FluxerLocalizationsAf extends FluxerLocalizations {
   String get userProfilePlutoniumBadgeTooltip => 'Fluxer Plutonium';
 
   @override
+  String userProfilePlutoniumSubscriberSinceTooltip(String date) {
+    return 'Fluxer Plutonium subscriber since $date';
+  }
+
+  @override
+  String get userProfileVisionaryBadgeTooltip => 'Fluxer Visionary';
+
+  @override
+  String userProfileVisionaryBadgeSinceTooltip(String date) {
+    return 'Fluxer Visionary since $date';
+  }
+
+  @override
   String userProfileVisionaryIdTooltip(int sequence) {
     return 'Visionary ID #$sequence';
   }

--- a/lib/l10n/generated/fluxer_localizations_ar.dart
+++ b/lib/l10n/generated/fluxer_localizations_ar.dart
@@ -2235,6 +2235,19 @@ class FluxerLocalizationsAr extends FluxerLocalizations {
   String get userProfilePlutoniumBadgeTooltip => 'Fluxer Plutonium';
 
   @override
+  String userProfilePlutoniumSubscriberSinceTooltip(String date) {
+    return 'Fluxer Plutonium subscriber since $date';
+  }
+
+  @override
+  String get userProfileVisionaryBadgeTooltip => 'Fluxer Visionary';
+
+  @override
+  String userProfileVisionaryBadgeSinceTooltip(String date) {
+    return 'Fluxer Visionary since $date';
+  }
+
+  @override
   String userProfileVisionaryIdTooltip(int sequence) {
     return 'Visionary ID #$sequence';
   }

--- a/lib/l10n/generated/fluxer_localizations_cs.dart
+++ b/lib/l10n/generated/fluxer_localizations_cs.dart
@@ -2235,6 +2235,19 @@ class FluxerLocalizationsCs extends FluxerLocalizations {
   String get userProfilePlutoniumBadgeTooltip => 'Fluxer Plutonium';
 
   @override
+  String userProfilePlutoniumSubscriberSinceTooltip(String date) {
+    return 'Fluxer Plutonium subscriber since $date';
+  }
+
+  @override
+  String get userProfileVisionaryBadgeTooltip => 'Fluxer Visionary';
+
+  @override
+  String userProfileVisionaryBadgeSinceTooltip(String date) {
+    return 'Fluxer Visionary since $date';
+  }
+
+  @override
   String userProfileVisionaryIdTooltip(int sequence) {
     return 'Visionary ID #$sequence';
   }

--- a/lib/l10n/generated/fluxer_localizations_cy.dart
+++ b/lib/l10n/generated/fluxer_localizations_cy.dart
@@ -2235,6 +2235,19 @@ class FluxerLocalizationsCy extends FluxerLocalizations {
   String get userProfilePlutoniumBadgeTooltip => 'Fluxer Plutonium';
 
   @override
+  String userProfilePlutoniumSubscriberSinceTooltip(String date) {
+    return 'Fluxer Plutonium subscriber since $date';
+  }
+
+  @override
+  String get userProfileVisionaryBadgeTooltip => 'Fluxer Visionary';
+
+  @override
+  String userProfileVisionaryBadgeSinceTooltip(String date) {
+    return 'Fluxer Visionary since $date';
+  }
+
+  @override
   String userProfileVisionaryIdTooltip(int sequence) {
     return 'Visionary ID #$sequence';
   }

--- a/lib/l10n/generated/fluxer_localizations_da.dart
+++ b/lib/l10n/generated/fluxer_localizations_da.dart
@@ -2235,6 +2235,19 @@ class FluxerLocalizationsDa extends FluxerLocalizations {
   String get userProfilePlutoniumBadgeTooltip => 'Fluxer Plutonium';
 
   @override
+  String userProfilePlutoniumSubscriberSinceTooltip(String date) {
+    return 'Fluxer Plutonium subscriber since $date';
+  }
+
+  @override
+  String get userProfileVisionaryBadgeTooltip => 'Fluxer Visionary';
+
+  @override
+  String userProfileVisionaryBadgeSinceTooltip(String date) {
+    return 'Fluxer Visionary since $date';
+  }
+
+  @override
   String userProfileVisionaryIdTooltip(int sequence) {
     return 'Visionary ID #$sequence';
   }

--- a/lib/l10n/generated/fluxer_localizations_de.dart
+++ b/lib/l10n/generated/fluxer_localizations_de.dart
@@ -2235,6 +2235,19 @@ class FluxerLocalizationsDe extends FluxerLocalizations {
   String get userProfilePlutoniumBadgeTooltip => 'Fluxer Plutonium';
 
   @override
+  String userProfilePlutoniumSubscriberSinceTooltip(String date) {
+    return 'Fluxer Plutonium subscriber since $date';
+  }
+
+  @override
+  String get userProfileVisionaryBadgeTooltip => 'Fluxer Visionary';
+
+  @override
+  String userProfileVisionaryBadgeSinceTooltip(String date) {
+    return 'Fluxer Visionary since $date';
+  }
+
+  @override
   String userProfileVisionaryIdTooltip(int sequence) {
     return 'Visionary ID #$sequence';
   }

--- a/lib/l10n/generated/fluxer_localizations_el.dart
+++ b/lib/l10n/generated/fluxer_localizations_el.dart
@@ -2235,6 +2235,19 @@ class FluxerLocalizationsEl extends FluxerLocalizations {
   String get userProfilePlutoniumBadgeTooltip => 'Fluxer Plutonium';
 
   @override
+  String userProfilePlutoniumSubscriberSinceTooltip(String date) {
+    return 'Fluxer Plutonium subscriber since $date';
+  }
+
+  @override
+  String get userProfileVisionaryBadgeTooltip => 'Fluxer Visionary';
+
+  @override
+  String userProfileVisionaryBadgeSinceTooltip(String date) {
+    return 'Fluxer Visionary since $date';
+  }
+
+  @override
   String userProfileVisionaryIdTooltip(int sequence) {
     return 'Visionary ID #$sequence';
   }

--- a/lib/l10n/generated/fluxer_localizations_en.dart
+++ b/lib/l10n/generated/fluxer_localizations_en.dart
@@ -2235,6 +2235,19 @@ class FluxerLocalizationsEn extends FluxerLocalizations {
   String get userProfilePlutoniumBadgeTooltip => 'Fluxer Plutonium';
 
   @override
+  String userProfilePlutoniumSubscriberSinceTooltip(String date) {
+    return 'Fluxer Plutonium subscriber since $date';
+  }
+
+  @override
+  String get userProfileVisionaryBadgeTooltip => 'Fluxer Visionary';
+
+  @override
+  String userProfileVisionaryBadgeSinceTooltip(String date) {
+    return 'Fluxer Visionary since $date';
+  }
+
+  @override
   String userProfileVisionaryIdTooltip(int sequence) {
     return 'Visionary ID #$sequence';
   }

--- a/lib/l10n/generated/fluxer_localizations_es.dart
+++ b/lib/l10n/generated/fluxer_localizations_es.dart
@@ -2235,6 +2235,19 @@ class FluxerLocalizationsEs extends FluxerLocalizations {
   String get userProfilePlutoniumBadgeTooltip => 'Fluxer Plutonium';
 
   @override
+  String userProfilePlutoniumSubscriberSinceTooltip(String date) {
+    return 'Fluxer Plutonium subscriber since $date';
+  }
+
+  @override
+  String get userProfileVisionaryBadgeTooltip => 'Fluxer Visionary';
+
+  @override
+  String userProfileVisionaryBadgeSinceTooltip(String date) {
+    return 'Fluxer Visionary since $date';
+  }
+
+  @override
   String userProfileVisionaryIdTooltip(int sequence) {
     return 'Visionary ID #$sequence';
   }

--- a/lib/l10n/generated/fluxer_localizations_et.dart
+++ b/lib/l10n/generated/fluxer_localizations_et.dart
@@ -2235,6 +2235,19 @@ class FluxerLocalizationsEt extends FluxerLocalizations {
   String get userProfilePlutoniumBadgeTooltip => 'Fluxer Plutonium';
 
   @override
+  String userProfilePlutoniumSubscriberSinceTooltip(String date) {
+    return 'Fluxer Plutonium subscriber since $date';
+  }
+
+  @override
+  String get userProfileVisionaryBadgeTooltip => 'Fluxer Visionary';
+
+  @override
+  String userProfileVisionaryBadgeSinceTooltip(String date) {
+    return 'Fluxer Visionary since $date';
+  }
+
+  @override
   String userProfileVisionaryIdTooltip(int sequence) {
     return 'Visionary ID #$sequence';
   }

--- a/lib/l10n/generated/fluxer_localizations_fa.dart
+++ b/lib/l10n/generated/fluxer_localizations_fa.dart
@@ -2235,6 +2235,19 @@ class FluxerLocalizationsFa extends FluxerLocalizations {
   String get userProfilePlutoniumBadgeTooltip => 'Fluxer Plutonium';
 
   @override
+  String userProfilePlutoniumSubscriberSinceTooltip(String date) {
+    return 'Fluxer Plutonium subscriber since $date';
+  }
+
+  @override
+  String get userProfileVisionaryBadgeTooltip => 'Fluxer Visionary';
+
+  @override
+  String userProfileVisionaryBadgeSinceTooltip(String date) {
+    return 'Fluxer Visionary since $date';
+  }
+
+  @override
   String userProfileVisionaryIdTooltip(int sequence) {
     return 'Visionary ID #$sequence';
   }

--- a/lib/l10n/generated/fluxer_localizations_fi.dart
+++ b/lib/l10n/generated/fluxer_localizations_fi.dart
@@ -2235,6 +2235,19 @@ class FluxerLocalizationsFi extends FluxerLocalizations {
   String get userProfilePlutoniumBadgeTooltip => 'Fluxer Plutonium';
 
   @override
+  String userProfilePlutoniumSubscriberSinceTooltip(String date) {
+    return 'Fluxer Plutonium subscriber since $date';
+  }
+
+  @override
+  String get userProfileVisionaryBadgeTooltip => 'Fluxer Visionary';
+
+  @override
+  String userProfileVisionaryBadgeSinceTooltip(String date) {
+    return 'Fluxer Visionary since $date';
+  }
+
+  @override
   String userProfileVisionaryIdTooltip(int sequence) {
     return 'Visionary ID #$sequence';
   }

--- a/lib/l10n/generated/fluxer_localizations_fr.dart
+++ b/lib/l10n/generated/fluxer_localizations_fr.dart
@@ -2235,6 +2235,19 @@ class FluxerLocalizationsFr extends FluxerLocalizations {
   String get userProfilePlutoniumBadgeTooltip => 'Fluxer Plutonium';
 
   @override
+  String userProfilePlutoniumSubscriberSinceTooltip(String date) {
+    return 'Fluxer Plutonium subscriber since $date';
+  }
+
+  @override
+  String get userProfileVisionaryBadgeTooltip => 'Fluxer Visionary';
+
+  @override
+  String userProfileVisionaryBadgeSinceTooltip(String date) {
+    return 'Fluxer Visionary since $date';
+  }
+
+  @override
   String userProfileVisionaryIdTooltip(int sequence) {
     return 'Visionary ID #$sequence';
   }

--- a/lib/l10n/generated/fluxer_localizations_ga.dart
+++ b/lib/l10n/generated/fluxer_localizations_ga.dart
@@ -2235,6 +2235,19 @@ class FluxerLocalizationsGa extends FluxerLocalizations {
   String get userProfilePlutoniumBadgeTooltip => 'Fluxer Plutonium';
 
   @override
+  String userProfilePlutoniumSubscriberSinceTooltip(String date) {
+    return 'Fluxer Plutonium subscriber since $date';
+  }
+
+  @override
+  String get userProfileVisionaryBadgeTooltip => 'Fluxer Visionary';
+
+  @override
+  String userProfileVisionaryBadgeSinceTooltip(String date) {
+    return 'Fluxer Visionary since $date';
+  }
+
+  @override
   String userProfileVisionaryIdTooltip(int sequence) {
     return 'Visionary ID #$sequence';
   }

--- a/lib/l10n/generated/fluxer_localizations_gl.dart
+++ b/lib/l10n/generated/fluxer_localizations_gl.dart
@@ -2235,6 +2235,19 @@ class FluxerLocalizationsGl extends FluxerLocalizations {
   String get userProfilePlutoniumBadgeTooltip => 'Fluxer Plutonium';
 
   @override
+  String userProfilePlutoniumSubscriberSinceTooltip(String date) {
+    return 'Fluxer Plutonium subscriber since $date';
+  }
+
+  @override
+  String get userProfileVisionaryBadgeTooltip => 'Fluxer Visionary';
+
+  @override
+  String userProfileVisionaryBadgeSinceTooltip(String date) {
+    return 'Fluxer Visionary since $date';
+  }
+
+  @override
   String userProfileVisionaryIdTooltip(int sequence) {
     return 'Visionary ID #$sequence';
   }

--- a/lib/l10n/generated/fluxer_localizations_hu.dart
+++ b/lib/l10n/generated/fluxer_localizations_hu.dart
@@ -2235,6 +2235,19 @@ class FluxerLocalizationsHu extends FluxerLocalizations {
   String get userProfilePlutoniumBadgeTooltip => 'Fluxer Plutonium';
 
   @override
+  String userProfilePlutoniumSubscriberSinceTooltip(String date) {
+    return 'Fluxer Plutonium subscriber since $date';
+  }
+
+  @override
+  String get userProfileVisionaryBadgeTooltip => 'Fluxer Visionary';
+
+  @override
+  String userProfileVisionaryBadgeSinceTooltip(String date) {
+    return 'Fluxer Visionary since $date';
+  }
+
+  @override
   String userProfileVisionaryIdTooltip(int sequence) {
     return 'Visionary ID #$sequence';
   }

--- a/lib/l10n/generated/fluxer_localizations_is.dart
+++ b/lib/l10n/generated/fluxer_localizations_is.dart
@@ -2235,6 +2235,19 @@ class FluxerLocalizationsIs extends FluxerLocalizations {
   String get userProfilePlutoniumBadgeTooltip => 'Fluxer Plutonium';
 
   @override
+  String userProfilePlutoniumSubscriberSinceTooltip(String date) {
+    return 'Fluxer Plutonium subscriber since $date';
+  }
+
+  @override
+  String get userProfileVisionaryBadgeTooltip => 'Fluxer Visionary';
+
+  @override
+  String userProfileVisionaryBadgeSinceTooltip(String date) {
+    return 'Fluxer Visionary since $date';
+  }
+
+  @override
   String userProfileVisionaryIdTooltip(int sequence) {
     return 'Visionary ID #$sequence';
   }

--- a/lib/l10n/generated/fluxer_localizations_it.dart
+++ b/lib/l10n/generated/fluxer_localizations_it.dart
@@ -2235,6 +2235,19 @@ class FluxerLocalizationsIt extends FluxerLocalizations {
   String get userProfilePlutoniumBadgeTooltip => 'Fluxer Plutonium';
 
   @override
+  String userProfilePlutoniumSubscriberSinceTooltip(String date) {
+    return 'Fluxer Plutonium subscriber since $date';
+  }
+
+  @override
+  String get userProfileVisionaryBadgeTooltip => 'Fluxer Visionary';
+
+  @override
+  String userProfileVisionaryBadgeSinceTooltip(String date) {
+    return 'Fluxer Visionary since $date';
+  }
+
+  @override
   String userProfileVisionaryIdTooltip(int sequence) {
     return 'Visionary ID #$sequence';
   }

--- a/lib/l10n/generated/fluxer_localizations_ja.dart
+++ b/lib/l10n/generated/fluxer_localizations_ja.dart
@@ -2235,6 +2235,19 @@ class FluxerLocalizationsJa extends FluxerLocalizations {
   String get userProfilePlutoniumBadgeTooltip => 'Fluxer Plutonium';
 
   @override
+  String userProfilePlutoniumSubscriberSinceTooltip(String date) {
+    return 'Fluxer Plutonium subscriber since $date';
+  }
+
+  @override
+  String get userProfileVisionaryBadgeTooltip => 'Fluxer Visionary';
+
+  @override
+  String userProfileVisionaryBadgeSinceTooltip(String date) {
+    return 'Fluxer Visionary since $date';
+  }
+
+  @override
   String userProfileVisionaryIdTooltip(int sequence) {
     return 'Visionary ID #$sequence';
   }

--- a/lib/l10n/generated/fluxer_localizations_ko.dart
+++ b/lib/l10n/generated/fluxer_localizations_ko.dart
@@ -2235,6 +2235,19 @@ class FluxerLocalizationsKo extends FluxerLocalizations {
   String get userProfilePlutoniumBadgeTooltip => 'Fluxer Plutonium';
 
   @override
+  String userProfilePlutoniumSubscriberSinceTooltip(String date) {
+    return 'Fluxer Plutonium subscriber since $date';
+  }
+
+  @override
+  String get userProfileVisionaryBadgeTooltip => 'Fluxer Visionary';
+
+  @override
+  String userProfileVisionaryBadgeSinceTooltip(String date) {
+    return 'Fluxer Visionary since $date';
+  }
+
+  @override
   String userProfileVisionaryIdTooltip(int sequence) {
     return 'Visionary ID #$sequence';
   }

--- a/lib/l10n/generated/fluxer_localizations_lt.dart
+++ b/lib/l10n/generated/fluxer_localizations_lt.dart
@@ -2235,6 +2235,19 @@ class FluxerLocalizationsLt extends FluxerLocalizations {
   String get userProfilePlutoniumBadgeTooltip => 'Fluxer Plutonium';
 
   @override
+  String userProfilePlutoniumSubscriberSinceTooltip(String date) {
+    return 'Fluxer Plutonium subscriber since $date';
+  }
+
+  @override
+  String get userProfileVisionaryBadgeTooltip => 'Fluxer Visionary';
+
+  @override
+  String userProfileVisionaryBadgeSinceTooltip(String date) {
+    return 'Fluxer Visionary since $date';
+  }
+
+  @override
   String userProfileVisionaryIdTooltip(int sequence) {
     return 'Visionary ID #$sequence';
   }

--- a/lib/l10n/generated/fluxer_localizations_lv.dart
+++ b/lib/l10n/generated/fluxer_localizations_lv.dart
@@ -2235,6 +2235,19 @@ class FluxerLocalizationsLv extends FluxerLocalizations {
   String get userProfilePlutoniumBadgeTooltip => 'Fluxer Plutonium';
 
   @override
+  String userProfilePlutoniumSubscriberSinceTooltip(String date) {
+    return 'Fluxer Plutonium subscriber since $date';
+  }
+
+  @override
+  String get userProfileVisionaryBadgeTooltip => 'Fluxer Visionary';
+
+  @override
+  String userProfileVisionaryBadgeSinceTooltip(String date) {
+    return 'Fluxer Visionary since $date';
+  }
+
+  @override
   String userProfileVisionaryIdTooltip(int sequence) {
     return 'Visionary ID #$sequence';
   }

--- a/lib/l10n/generated/fluxer_localizations_nb.dart
+++ b/lib/l10n/generated/fluxer_localizations_nb.dart
@@ -2235,6 +2235,19 @@ class FluxerLocalizationsNb extends FluxerLocalizations {
   String get userProfilePlutoniumBadgeTooltip => 'Fluxer Plutonium';
 
   @override
+  String userProfilePlutoniumSubscriberSinceTooltip(String date) {
+    return 'Fluxer Plutonium subscriber since $date';
+  }
+
+  @override
+  String get userProfileVisionaryBadgeTooltip => 'Fluxer Visionary';
+
+  @override
+  String userProfileVisionaryBadgeSinceTooltip(String date) {
+    return 'Fluxer Visionary since $date';
+  }
+
+  @override
   String userProfileVisionaryIdTooltip(int sequence) {
     return 'Visionary ID #$sequence';
   }

--- a/lib/l10n/generated/fluxer_localizations_pl.dart
+++ b/lib/l10n/generated/fluxer_localizations_pl.dart
@@ -2235,6 +2235,19 @@ class FluxerLocalizationsPl extends FluxerLocalizations {
   String get userProfilePlutoniumBadgeTooltip => 'Fluxer Plutonium';
 
   @override
+  String userProfilePlutoniumSubscriberSinceTooltip(String date) {
+    return 'Fluxer Plutonium subscriber since $date';
+  }
+
+  @override
+  String get userProfileVisionaryBadgeTooltip => 'Fluxer Visionary';
+
+  @override
+  String userProfileVisionaryBadgeSinceTooltip(String date) {
+    return 'Fluxer Visionary since $date';
+  }
+
+  @override
   String userProfileVisionaryIdTooltip(int sequence) {
     return 'Visionary ID #$sequence';
   }

--- a/lib/l10n/generated/fluxer_localizations_pt.dart
+++ b/lib/l10n/generated/fluxer_localizations_pt.dart
@@ -2235,6 +2235,19 @@ class FluxerLocalizationsPt extends FluxerLocalizations {
   String get userProfilePlutoniumBadgeTooltip => 'Fluxer Plutonium';
 
   @override
+  String userProfilePlutoniumSubscriberSinceTooltip(String date) {
+    return 'Fluxer Plutonium subscriber since $date';
+  }
+
+  @override
+  String get userProfileVisionaryBadgeTooltip => 'Fluxer Visionary';
+
+  @override
+  String userProfileVisionaryBadgeSinceTooltip(String date) {
+    return 'Fluxer Visionary since $date';
+  }
+
+  @override
   String userProfileVisionaryIdTooltip(int sequence) {
     return 'Visionary ID #$sequence';
   }

--- a/lib/l10n/generated/fluxer_localizations_ru.dart
+++ b/lib/l10n/generated/fluxer_localizations_ru.dart
@@ -2235,6 +2235,19 @@ class FluxerLocalizationsRu extends FluxerLocalizations {
   String get userProfilePlutoniumBadgeTooltip => 'Fluxer Plutonium';
 
   @override
+  String userProfilePlutoniumSubscriberSinceTooltip(String date) {
+    return 'Fluxer Plutonium subscriber since $date';
+  }
+
+  @override
+  String get userProfileVisionaryBadgeTooltip => 'Fluxer Visionary';
+
+  @override
+  String userProfileVisionaryBadgeSinceTooltip(String date) {
+    return 'Fluxer Visionary since $date';
+  }
+
+  @override
   String userProfileVisionaryIdTooltip(int sequence) {
     return 'Visionary ID #$sequence';
   }

--- a/lib/l10n/generated/fluxer_localizations_sk.dart
+++ b/lib/l10n/generated/fluxer_localizations_sk.dart
@@ -2235,6 +2235,19 @@ class FluxerLocalizationsSk extends FluxerLocalizations {
   String get userProfilePlutoniumBadgeTooltip => 'Fluxer Plutonium';
 
   @override
+  String userProfilePlutoniumSubscriberSinceTooltip(String date) {
+    return 'Fluxer Plutonium subscriber since $date';
+  }
+
+  @override
+  String get userProfileVisionaryBadgeTooltip => 'Fluxer Visionary';
+
+  @override
+  String userProfileVisionaryBadgeSinceTooltip(String date) {
+    return 'Fluxer Visionary since $date';
+  }
+
+  @override
   String userProfileVisionaryIdTooltip(int sequence) {
     return 'Visionary ID #$sequence';
   }

--- a/lib/l10n/generated/fluxer_localizations_sl.dart
+++ b/lib/l10n/generated/fluxer_localizations_sl.dart
@@ -2235,6 +2235,19 @@ class FluxerLocalizationsSl extends FluxerLocalizations {
   String get userProfilePlutoniumBadgeTooltip => 'Fluxer Plutonium';
 
   @override
+  String userProfilePlutoniumSubscriberSinceTooltip(String date) {
+    return 'Fluxer Plutonium subscriber since $date';
+  }
+
+  @override
+  String get userProfileVisionaryBadgeTooltip => 'Fluxer Visionary';
+
+  @override
+  String userProfileVisionaryBadgeSinceTooltip(String date) {
+    return 'Fluxer Visionary since $date';
+  }
+
+  @override
   String userProfileVisionaryIdTooltip(int sequence) {
     return 'Visionary ID #$sequence';
   }

--- a/lib/l10n/generated/fluxer_localizations_sr.dart
+++ b/lib/l10n/generated/fluxer_localizations_sr.dart
@@ -2235,6 +2235,19 @@ class FluxerLocalizationsSr extends FluxerLocalizations {
   String get userProfilePlutoniumBadgeTooltip => 'Fluxer Plutonium';
 
   @override
+  String userProfilePlutoniumSubscriberSinceTooltip(String date) {
+    return 'Fluxer Plutonium subscriber since $date';
+  }
+
+  @override
+  String get userProfileVisionaryBadgeTooltip => 'Fluxer Visionary';
+
+  @override
+  String userProfileVisionaryBadgeSinceTooltip(String date) {
+    return 'Fluxer Visionary since $date';
+  }
+
+  @override
   String userProfileVisionaryIdTooltip(int sequence) {
     return 'Visionary ID #$sequence';
   }

--- a/lib/l10n/generated/fluxer_localizations_sv.dart
+++ b/lib/l10n/generated/fluxer_localizations_sv.dart
@@ -2235,6 +2235,19 @@ class FluxerLocalizationsSv extends FluxerLocalizations {
   String get userProfilePlutoniumBadgeTooltip => 'Fluxer Plutonium';
 
   @override
+  String userProfilePlutoniumSubscriberSinceTooltip(String date) {
+    return 'Fluxer Plutonium subscriber since $date';
+  }
+
+  @override
+  String get userProfileVisionaryBadgeTooltip => 'Fluxer Visionary';
+
+  @override
+  String userProfileVisionaryBadgeSinceTooltip(String date) {
+    return 'Fluxer Visionary since $date';
+  }
+
+  @override
   String userProfileVisionaryIdTooltip(int sequence) {
     return 'Visionary ID #$sequence';
   }

--- a/lib/l10n/generated/fluxer_localizations_th.dart
+++ b/lib/l10n/generated/fluxer_localizations_th.dart
@@ -2235,6 +2235,19 @@ class FluxerLocalizationsTh extends FluxerLocalizations {
   String get userProfilePlutoniumBadgeTooltip => 'Fluxer Plutonium';
 
   @override
+  String userProfilePlutoniumSubscriberSinceTooltip(String date) {
+    return 'Fluxer Plutonium subscriber since $date';
+  }
+
+  @override
+  String get userProfileVisionaryBadgeTooltip => 'Fluxer Visionary';
+
+  @override
+  String userProfileVisionaryBadgeSinceTooltip(String date) {
+    return 'Fluxer Visionary since $date';
+  }
+
+  @override
   String userProfileVisionaryIdTooltip(int sequence) {
     return 'Visionary ID #$sequence';
   }

--- a/lib/l10n/generated/fluxer_localizations_tr.dart
+++ b/lib/l10n/generated/fluxer_localizations_tr.dart
@@ -2235,6 +2235,19 @@ class FluxerLocalizationsTr extends FluxerLocalizations {
   String get userProfilePlutoniumBadgeTooltip => 'Fluxer Plutonium';
 
   @override
+  String userProfilePlutoniumSubscriberSinceTooltip(String date) {
+    return 'Fluxer Plutonium subscriber since $date';
+  }
+
+  @override
+  String get userProfileVisionaryBadgeTooltip => 'Fluxer Visionary';
+
+  @override
+  String userProfileVisionaryBadgeSinceTooltip(String date) {
+    return 'Fluxer Visionary since $date';
+  }
+
+  @override
   String userProfileVisionaryIdTooltip(int sequence) {
     return 'Visionary ID #$sequence';
   }

--- a/lib/l10n/generated/fluxer_localizations_uk.dart
+++ b/lib/l10n/generated/fluxer_localizations_uk.dart
@@ -2235,6 +2235,19 @@ class FluxerLocalizationsUk extends FluxerLocalizations {
   String get userProfilePlutoniumBadgeTooltip => 'Fluxer Plutonium';
 
   @override
+  String userProfilePlutoniumSubscriberSinceTooltip(String date) {
+    return 'Fluxer Plutonium subscriber since $date';
+  }
+
+  @override
+  String get userProfileVisionaryBadgeTooltip => 'Fluxer Visionary';
+
+  @override
+  String userProfileVisionaryBadgeSinceTooltip(String date) {
+    return 'Fluxer Visionary since $date';
+  }
+
+  @override
   String userProfileVisionaryIdTooltip(int sequence) {
     return 'Visionary ID #$sequence';
   }

--- a/lib/l10n/generated/fluxer_localizations_zh.dart
+++ b/lib/l10n/generated/fluxer_localizations_zh.dart
@@ -2235,6 +2235,19 @@ class FluxerLocalizationsZh extends FluxerLocalizations {
   String get userProfilePlutoniumBadgeTooltip => 'Fluxer Plutonium';
 
   @override
+  String userProfilePlutoniumSubscriberSinceTooltip(String date) {
+    return 'Fluxer Plutonium subscriber since $date';
+  }
+
+  @override
+  String get userProfileVisionaryBadgeTooltip => 'Fluxer Visionary';
+
+  @override
+  String userProfileVisionaryBadgeSinceTooltip(String date) {
+    return 'Fluxer Visionary since $date';
+  }
+
+  @override
   String userProfileVisionaryIdTooltip(int sequence) {
     return 'Visionary ID #$sequence';
   }

--- a/test/features/profile/presentation/widgets/user_profile_badges_test.dart
+++ b/test/features/profile/presentation/widgets/user_profile_badges_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:fluxer_app/core/theme/fluxer_layout_theme.dart';
@@ -6,19 +7,24 @@ import 'package:fluxer_app/core/theme/fluxer_text_theme.dart';
 import 'package:fluxer_app/core/theme/fluxer_theme.dart';
 import 'package:fluxer_app/core/theme/themes/dark.dart';
 import 'package:fluxer_app/features/profile/presentation/widgets/user_profile_badges.dart';
+import 'package:fluxer_app/features/ui/toast/fluxer_toast_overlay.dart';
 import 'package:fluxer_app/l10n/generated/fluxer_localizations.dart';
 
 Widget _buildApp(Widget child) {
   final colorTheme = buildDarkColorTheme();
-  return MaterialApp(
-    localizationsDelegates: FluxerLocalizations.localizationsDelegates,
-    supportedLocales: FluxerLocalizations.supportedLocales,
-    theme: buildFluxerTheme(
-      colorTheme: colorTheme,
-      textTheme: FluxerTextTheme.fromColors(colorTheme),
-      layoutTheme: FluxerLayoutTheme.scaled(),
+  return ProviderScope(
+    child: MaterialApp(
+      localizationsDelegates: FluxerLocalizations.localizationsDelegates,
+      supportedLocales: FluxerLocalizations.supportedLocales,
+      theme: buildFluxerTheme(
+        colorTheme: colorTheme,
+        textTheme: FluxerTextTheme.fromColors(colorTheme),
+        layoutTheme: FluxerLayoutTheme.scaled(),
+      ),
+      home: FluxerToastOverlay(
+        child: Scaffold(body: Center(child: child)),
+      ),
     ),
-    home: child,
   );
 }
 
@@ -60,6 +66,76 @@ void main() {
       );
       expect(find.byType(SvgPicture), findsOneWidget);
       expect(find.byTooltip('Fluxer Plutonium'), findsOneWidget);
+    });
+
+    testWidgets('tapping a badge reveals its name as a toast', (tester) async {
+      await tester.pumpWidget(_buildApp(const UserProfileBadges(flags: 1)));
+
+      await tester.tap(find.byType(SvgPicture));
+      await tester.pump();
+
+      expect(find.text('Fluxer Staff'), findsOneWidget);
+    });
+
+    testWidgets('tapping a lifetime Plutonium badge toasts Visionary since', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _buildApp(
+          const UserProfileBadges(
+            flags: 0,
+            hasPlutonium: true,
+            isLifetimePlutonium: true,
+            premiumSince: '2026-03-14',
+          ),
+        ),
+      );
+
+      await tester.tap(find.byType(SvgPicture));
+      await tester.pump();
+
+      expect(find.text('Fluxer Visionary since Mar 14, 2026'), findsOneWidget);
+    });
+
+    testWidgets('tapping a dateless lifetime badge toasts Visionary', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _buildApp(
+          const UserProfileBadges(
+            flags: 0,
+            hasPlutonium: true,
+            isLifetimePlutonium: true,
+          ),
+        ),
+      );
+
+      await tester.tap(find.byType(SvgPicture));
+      await tester.pump();
+
+      expect(find.text('Fluxer Visionary'), findsOneWidget);
+    });
+
+    testWidgets('tapping a subscriber Plutonium badge toasts subscriber since', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _buildApp(
+          const UserProfileBadges(
+            flags: 0,
+            hasPlutonium: true,
+            premiumSince: '2026-03-14',
+          ),
+        ),
+      );
+
+      await tester.tap(find.byType(SvgPicture));
+      await tester.pump();
+
+      expect(
+        find.text('Fluxer Plutonium subscriber since Mar 14, 2026'),
+        findsOneWidget,
+      );
     });
 
     testWidgets('renders Visionary ID when sequence is provided', (


### PR DESCRIPTION
# What this PR solves/adds

Makes badges tappable.

- Tapping badges now uses `FluxerToast`
  - Strings for the toast match desktop (and have been added where necessary)
- Removed duplicate definitions of flags
- Removed duplicate logic of rendering badges
- Unified the display logic
  - This coincidentally fixed the CTP badge not appearing in profile previews, which is good

## PR type

- [x] Feature
- [ ] Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Feature requirements

<details>
<summary>Visual proof</summary>

https://github.com/user-attachments/assets/5164fb21-ee8b-4fc5-82e0-dd592e47e1a7

<img width="201" height="437" alt="Simulator Screenshot - iPhone 17 Pro - 2026-06-20 at 04 18 28" src="https://github.com/user-attachments/assets/7babf9ea-aed5-4cc6-b03a-b765fba03d04" />

<img width="201" height="437" alt="image" src="https://github.com/user-attachments/assets/8227acba-d5d6-45ac-b833-a0e02d46b978" />

</details>

## Validation

- [x] I explained what this PR solves or adds.
- [x] I verified the changes locally.
- [x] I completed all required feature items, or marked them as `N/A` if not applicable.

## Release Notes

- Added toasts to badges
