### PR TITLE
fix(fluxer_en): remove duplicated definitions

### DIFF
--- a/lib/l10n/fluxer_en.arb
+++ b/lib/l10n/fluxer_en.arb
@@ -2832,28 +2832,6 @@
       }
     }
   },
-  "userProfilePlutoniumSubscriberSinceTooltip": "Fluxer Plutonium subscriber since {date}",
-  "@userProfilePlutoniumSubscriberSinceTooltip": {
-    "description": "Tooltip and semantic label for the Plutonium badge on a user profile, including the date the user began subscribing.",
-    "placeholders": {
-      "date": {
-        "type": "String"
-      }
-    }
-  },
-  "userProfileVisionaryBadgeTooltip": "Fluxer Visionary",
-  "@userProfileVisionaryBadgeTooltip": {
-    "description": "Tooltip and semantic label for the lifetime Plutonium (Visionary) badge on a user profile."
-  },
-  "userProfileVisionaryBadgeSinceTooltip": "Fluxer Visionary since {date}",
-  "@userProfileVisionaryBadgeSinceTooltip": {
-    "description": "Tooltip and semantic label for the lifetime Plutonium (Visionary) badge on a user profile, including the date the user became a Visionary.",
-    "placeholders": {
-      "date": {
-        "type": "String"
-      }
-    }
-  },
   "userProfileVisionaryIdTooltip": "Visionary ID #{sequence}",
   "@userProfileVisionaryIdTooltip": {
     "description": "Short label in the user profile badges popout. Keep it concise. Preserve {sequence}; it is inserted by code.",

--- a/lib/l10n/fluxer_en.arb
+++ b/lib/l10n/fluxer_en.arb
@@ -119,7 +119,7 @@
   },
   "cancel": "Cancel",
   "@cancel": {
-    "description": "Generic cancel action label."
+    "description": "Generic cancel button label."
   },
   "ipAuthCheckEmail": "Check your email",
   "@ipAuthCheckEmail": {
@@ -169,7 +169,7 @@
   },
   "back": "Back",
   "@back": {
-    "description": "Generic back navigation label."
+    "description": "Generic back button label."
   },
   "mfaTitle": "Two-factor authentication",
   "@mfaTitle": {
@@ -1651,7 +1651,7 @@
   },
   "continueAction": "Continue",
   "@continueAction": {
-    "description": "Generic continue action button label."
+    "description": "Generic continue button label."
   },
 
   "profileCustomizationTitle": "Profile Customization",
@@ -2170,10 +2170,6 @@
   "@verify": {
     "description": "Generic verify button label."
   },
-  "cancel": "Cancel",
-  "@cancel": {
-    "description": "Generic cancel button label."
-  },
   "enable": "Enable",
   "@enable": {
     "description": "Generic enable button label."
@@ -2583,15 +2579,6 @@
   "claimAccountSuccess": "Account claimed successfully",
   "@claimAccountSuccess": {
     "description": "Toast after account claimed."
-  },
-
-  "continueAction": "Continue",
-  "@continueAction": {
-    "description": "Generic continue button label."
-  },
-  "back": "Back",
-  "@back": {
-    "description": "Generic back button label."
   },
   "importantInformation": "Important information:",
   "@importantInformation": {


### PR DESCRIPTION
# What this PR solves/adds

Introduced by #369, there were 3 keys that existed prior and have been duplicated. Makes `flutter gen-l10` confused.

There were also pre-existing duplicates. I chose to remove the definitions that made the diff smallest by updating the placement with the generated output.

## PR type

- [ ] Feature
- [x] Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Feature requirements

- GitHub Discussion link: N/A
- Visual proof (screenshot or video): N/A

## Validation

- [x] I explained what this PR solves or adds.
- [x] I verified the changes locally.
- [x] I completed all required feature items, or marked them as `N/A` if not applicable.

## Release Notes

- N/A
