### PR TITLE
fix: remove role colours for backgrounds

### DIFF
--- a/lib/features/chat/presentation/widgets/composer/composer_autocomplete_field_state.dart
+++ b/lib/features/chat/presentation/widgets/composer/composer_autocomplete_field_state.dart
@@ -825,11 +825,10 @@ class ComposerAutocompleteFieldState
                       ? memberDisplayLabel(m)
                       : null,
                   userAvatarColor: m?.avatarColor,
-                  userAvatarRoleColor: m?.roleColor,
                   userAvatarStatus: m == null
                       ? null
                       : ref.watch(userPresenceProvider(m.id)).value?.status ??
-                          m.status,
+                            m.status,
                   emojiSurrogates: row.emojiSurrogates,
                   emojiImageUrl: row.emojiImageUrl,
                 );

--- a/lib/features/chat/presentation/widgets/composer/composer_autocomplete_panel.dart
+++ b/lib/features/chat/presentation/widgets/composer/composer_autocomplete_panel.dart
@@ -40,7 +40,6 @@ class ComposerAutocompletePanelListTile extends StatelessWidget {
     this.userAvatarImageUrl,
     this.userAvatarFallbackText,
     this.userAvatarColor,
-    this.userAvatarRoleColor,
     this.userAvatarStatus,
     this.emojiSurrogates,
     this.emojiImageUrl,
@@ -57,7 +56,6 @@ class ComposerAutocompletePanelListTile extends StatelessWidget {
   final String? userAvatarImageUrl;
   final String? userAvatarFallbackText;
   final int? userAvatarColor;
-  final int? userAvatarRoleColor;
   final String? userAvatarStatus;
   final String? emojiSurrogates;
   final String? emojiImageUrl;
@@ -110,7 +108,6 @@ class ComposerAutocompletePanelListTile extends StatelessWidget {
                             userAvatarUserId,
                           ),
                           avatarColor: userAvatarColor,
-                          roleColor: userAvatarRoleColor,
                           status: userAvatarStatus,
                           size: _kAutocompleteAvatarSize,
                         ),

--- a/lib/features/members/presentation/widgets/member_list_member_row.dart
+++ b/lib/features/members/presentation/widgets/member_list_member_row.dart
@@ -99,7 +99,6 @@ class _MemberListSidebarMemberRowState
                         hash: avatar,
                       ),
                       avatarColor: member.user.avatarColor,
-                      roleColor: roleColor,
                       status: status,
                       size: 32,
                     ),
@@ -209,7 +208,6 @@ class MemberListDetailsMemberRow extends ConsumerWidget {
                   hash: avatar,
                 ),
                 avatarColor: member.user.avatarColor,
-                roleColor: roleColor,
                 status: status,
                 size: 32,
               ),
@@ -246,7 +244,8 @@ class MemberListDetailsMemberRow extends ConsumerWidget {
                         ],
                       ],
                     ),
-                    if (customStatus != null && customStatus.isNotEmpty) ...<Widget>[
+                    if (customStatus != null &&
+                        customStatus.isNotEmpty) ...<Widget>[
                       const SizedBox(height: 2),
                       Text(
                         customStatus,

--- a/lib/features/ui/avatar/fluxer_avatar.dart
+++ b/lib/features/ui/avatar/fluxer_avatar.dart
@@ -30,7 +30,6 @@ class FluxerAvatar extends StatelessWidget {
        status = null,
        showStatus = false,
        avatarColor = null,
-       roleColor = null,
        _userId = null,
        icon = null,
        iconColor = null,
@@ -43,7 +42,6 @@ class FluxerAvatar extends StatelessWidget {
     this.size = 40,
     this.showStatus = true,
     this.avatarColor,
-    this.roleColor,
     this.cacheKey,
     String? userId,
     super.key,
@@ -63,7 +61,6 @@ class FluxerAvatar extends StatelessWidget {
        status = null,
        showStatus = false,
        avatarColor = null,
-       roleColor = null,
        _userId = null,
        icon = null,
        iconColor = null,
@@ -83,7 +80,6 @@ class FluxerAvatar extends StatelessWidget {
        status = null,
        showStatus = false,
        avatarColor = null,
-       roleColor = null,
        _userId = null;
 
   factory FluxerAvatar.fromUserRow(
@@ -113,7 +109,6 @@ class FluxerAvatar extends StatelessWidget {
   final String? status;
   final bool showStatus;
   final int? avatarColor;
-  final int? roleColor;
   final _AvatarShape _shape;
   final String? _userId;
   final IconData? icon;
@@ -133,9 +128,6 @@ class FluxerAvatar extends StatelessWidget {
   }
 
   Color get _backgroundColor {
-    if (roleColor != null) {
-      return Color(roleColor!);
-    }
     if (avatarColor != null) {
       return Color(avatarColor!);
     }
@@ -212,29 +204,21 @@ class FluxerAvatar extends StatelessWidget {
           ),
         ),
       );
-    } else {
-      avatarContent = Container(
-        width: size,
-        height: size,
-        decoration: BoxDecoration(
-          color: _backgroundColor,
-          borderRadius: _borderRadius,
-        ),
-        child: ClipRRect(
-          borderRadius: _borderRadius,
-          child: resolvedUrl != null
-              ? CachedNetworkImage(
-                  imageUrl: resolvedUrl,
-                  cacheKey: cacheKey,
-                  width: size,
-                  height: size,
-                  memCacheWidth: (size * dpr).round(),
-                  fit: BoxFit.cover,
-                  errorBuilder: (_, _, _) => _buildFallback(context),
-                )
-              : _buildFallback(context),
+    } else if (resolvedUrl != null) {
+      avatarContent = ClipRRect(
+        borderRadius: _borderRadius,
+        child: CachedNetworkImage(
+          imageUrl: resolvedUrl,
+          cacheKey: cacheKey,
+          width: size,
+          height: size,
+          memCacheWidth: (size * dpr).round(),
+          fit: BoxFit.cover,
+          errorBuilder: (_, _, _) => _buildFallbackAvatar(context),
         ),
       );
+    } else {
+      avatarContent = _buildFallbackAvatar(context);
     }
 
     if (hasStatus) {
@@ -265,6 +249,18 @@ class FluxerAvatar extends StatelessWidget {
             ),
         ],
       ),
+    );
+  }
+
+  Widget _buildFallbackAvatar(BuildContext context) {
+    return Container(
+      width: size,
+      height: size,
+      decoration: BoxDecoration(
+        color: _backgroundColor,
+        borderRadius: _borderRadius,
+      ),
+      child: _buildFallback(context),
     );
   }
 

--- a/lib/features/ui/avatar/fluxer_avatar_cluster.dart
+++ b/lib/features/ui/avatar/fluxer_avatar_cluster.dart
@@ -211,23 +211,25 @@ class FluxerAvatarCluster extends StatelessWidget {
     final fallbackColor =
         _kAccentColors[text.hashCode.abs() % _kAccentColors.length];
 
-    return Container(
-      width: avatarSize,
-      height: avatarSize,
-      decoration: BoxDecoration(shape: BoxShape.circle, color: fallbackColor),
-      clipBehavior: Clip.antiAlias,
-      child: CachedNetworkImage(
-        imageUrl: member.resolvedImageUrl,
+    return ClipOval(
+      child: SizedBox(
         width: avatarSize,
         height: avatarSize,
-        fit: BoxFit.cover,
-        errorBuilder: (_, _, _) => Center(
-          child: Text(
-            initial,
-            style: TextStyle(
-              color: Colors.white,
-              fontSize: avatarSize * 0.4,
-              fontWeight: FontWeight.w600,
+        child: CachedNetworkImage(
+          imageUrl: member.resolvedImageUrl,
+          width: avatarSize,
+          height: avatarSize,
+          fit: BoxFit.cover,
+          errorBuilder: (_, _, _) => Container(
+            color: fallbackColor,
+            alignment: Alignment.center,
+            child: Text(
+              initial,
+              style: TextStyle(
+                color: Colors.white,
+                fontSize: avatarSize * 0.4,
+                fontWeight: FontWeight.w600,
+              ),
             ),
           ),
         ),


### PR DESCRIPTION
# What this PR solves/adds

Removed the role colours fallback on avatar images. Transparent images now show surrounding UI just like desktop (parity too).

Resolves #372.

## PR type

- [ ] Feature
- [x] Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Feature requirements

- GitHub Discussion link: N/A
- Visual proof (screenshot or video): N/A

## Validation

- [x] I explained what this PR solves or adds.
- [x] I verified the changes locally.
- [x] I completed all required feature items, or marked them as `N/A` if not applicable.

## Release Notes

- Fixed profile pictures rendering with solid background colours
