### PR TITLE
fix(guild_navbar): centre communities in collapsed folders

### DIFF
--- a/lib/features/guilds/presentation/widgets/guild_navbar.dart
+++ b/lib/features/guilds/presentation/widgets/guild_navbar.dart
@@ -1234,39 +1234,46 @@ class _GuildFolderWidgetState extends ConsumerState<_GuildFolderWidget>
 
     // 2x2 mini guild icon grid.
     final gridGuilds = folder.guilds.take(4).toList();
-    return Padding(
-      padding: const EdgeInsets.all(6),
-      child: Wrap(
-        spacing: 2,
-        runSpacing: 2,
-        children: [
-          for (final guild in gridGuilds)
-            SizedBox(
-              width: 16,
-              height: 16,
-              child: ClipRRect(
-                borderRadius: BorderRadius.circular(16 * 0.3),
-                child: guild.iconUrl != null
-                    ? CachedNetworkImage(
-                        imageUrl: guild.iconUrl!,
-                        fit: BoxFit.cover,
-                      )
-                    : ColoredBox(
-                        color: context.colors.serverIconBackground,
-                        child: Center(
-                          child: Text(
-                            abbreviateGuildName(guild.name, maxLength: 2),
-                            style: const TextStyle(
-                              fontSize: 8,
-                              fontWeight: FontWeight.w600,
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        const double gridPadding = 4;
+        const double gridGap = 2;
+        final double cellSize =
+            (constraints.maxWidth - gridPadding * 2 - gridGap) / 2;
+        return Padding(
+          padding: const EdgeInsets.all(gridPadding),
+          child: Wrap(
+            spacing: gridGap,
+            runSpacing: gridGap,
+            children: [
+              for (final guild in gridGuilds)
+                SizedBox.square(
+                  dimension: cellSize,
+                  child: ClipRRect(
+                    borderRadius: BorderRadius.circular(cellSize * 0.3),
+                    child: guild.iconUrl != null
+                        ? CachedNetworkImage(
+                            imageUrl: guild.iconUrl!,
+                            fit: BoxFit.cover,
+                          )
+                        : ColoredBox(
+                            color: context.colors.serverIconBackground,
+                            child: Center(
+                              child: Text(
+                                abbreviateGuildName(guild.name, maxLength: 2),
+                                style: const TextStyle(
+                                  fontSize: 8,
+                                  fontWeight: FontWeight.w600,
+                                ),
+                              ),
                             ),
                           ),
-                        ),
-                      ),
-              ),
-            ),
-        ],
-      ),
+                  ),
+                ),
+            ],
+          ),
+        );
+      },
     );
   }
 


### PR DESCRIPTION
# What this PR solves/adds

Resolves #374. The calculations were 1 px out, but now, this matches desktop where it fills the tile. Also minimised the magic numbers/hard-coded numbers.

Additionally, there were some pre-existing formatting issues as part of this diff.

<details><summary>Evidence</summary>

<img width="201" height="437" alt="image" src="https://github.com/user-attachments/assets/4a13a4a9-6709-4fb5-a18f-d24ecd7fd320" />

</details> 

## PR type

- [ ] Feature
- [x] Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Feature requirements

- GitHub Discussion link: N/A
- Visual proof (screenshot or video): N/A

## Validation

- [x] I explained what this PR solves or adds.
- [x] I verified the changes locally.
- [x] I completed all required feature items, or marked them as `N/A` if not applicable.

## Release Notes

- Fixed centring for communities in collapsed folders
