### PR TITLE
fix: preserve labels for masked channel and message links

### DIFF
--- a/packages/fluxer_markdown/lib/src/renderers/fluxer_markdown_renderers.dart
+++ b/packages/fluxer_markdown/lib/src/renderers/fluxer_markdown_renderers.dart
@@ -644,11 +644,6 @@ class _MarkdownInlineRenderer {
     final href = element.attributes['href'] ?? element.textContent;
     final text = element.textContent;
     final linkColor = config.linkColor ?? Theme.of(context).colorScheme.primary;
-    final widget = config.linkWidgetBuilder?.call(context, href, style);
-
-    if (widget != null) {
-      return WidgetSpan(alignment: PlaceholderAlignment.middle, child: widget);
-    }
 
     return TextSpan(
       text: text,

--- a/packages/fluxer_markdown/test/message_text_flow_test.dart
+++ b/packages/fluxer_markdown/test/message_text_flow_test.dart
@@ -12,6 +12,9 @@ const FluxerMarkdownConfig _testMarkdownConfig = FluxerMarkdownConfig(
   unicodeEmojiUrlBuilder: _noopUnicodeEmojiUrl,
   customEmojiUrlBuilder: _noopCustomEmojiUrl,
 );
+final RegExp _internalFluxerLinkPattern = RegExp(
+  r'https://web\.fluxer\.app/channels/\d+/\d+/\d+',
+);
 
 String? _noopEmojiShortcode(String name) => null;
 
@@ -170,6 +173,101 @@ void main() {
       await tester.tapOnText(find.textRange.ofSubstring(url));
 
       expect(tappedHref, url);
+    });
+
+    testWidgets('labeled message links keep their markdown label', (
+      tester,
+    ) async {
+      const String url =
+          'https://web.fluxer.app/channels/123456789012345678/'
+          '987654321098765432/111111111111111111';
+      String? tappedHref;
+      final FluxerMarkdownConfig config = FluxerMarkdownConfig(
+        resolveEmojiShortcode: _noopEmojiShortcode,
+        unicodeEmojiUrlBuilder: _noopUnicodeEmojiUrl,
+        customEmojiUrlBuilder: _noopCustomEmojiUrl,
+        internalLinkPattern: _internalFluxerLinkPattern,
+        linkWidgetBuilder: (_, _, _) => const Text('jump pill'),
+        onTapLink: (_, href) async {
+          tappedHref = href;
+        },
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: FluxerMarkdown(data: '[#510]($url)', config: config),
+          ),
+        ),
+      );
+
+      expect(find.text('#510', findRichText: true), findsOneWidget);
+      expect(find.text('jump pill'), findsNothing);
+
+      await tester.tapOnText(find.textRange.ofSubstring('#510'));
+
+      expect(tappedHref, url);
+    });
+
+    testWidgets('labeled channel links keep their label without a pill', (
+      tester,
+    ) async {
+      const String url =
+          'https://web.canary.fluxer.app/channels/1500175496099627169/'
+          '1500176315272364202';
+      String? tappedHref;
+      final FluxerMarkdownConfig config = FluxerMarkdownConfig(
+        resolveEmojiShortcode: _noopEmojiShortcode,
+        unicodeEmojiUrlBuilder: _noopUnicodeEmojiUrl,
+        customEmojiUrlBuilder: _noopCustomEmojiUrl,
+        internalLinkPattern: RegExp(
+          r'https://web\.canary\.fluxer\.app/channels/\d+/\d+',
+        ),
+        linkWidgetBuilder: (_, _, _) => const Text('jump pill'),
+        onTapLink: (_, href) async {
+          tappedHref = href;
+        },
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: FluxerMarkdown(data: '[hi]($url)', config: config),
+          ),
+        ),
+      );
+
+      expect(find.text('hi', findRichText: true), findsOneWidget);
+      expect(find.text('jump pill'), findsNothing);
+
+      await tester.tapOnText(find.textRange.ofSubstring('hi'));
+
+      expect(tappedHref, url);
+    });
+
+    testWidgets('bare message links can render custom jump widgets', (
+      tester,
+    ) async {
+      const String url =
+          'https://web.fluxer.app/channels/123456789012345678/'
+          '987654321098765432/111111111111111111';
+      final FluxerMarkdownConfig config = FluxerMarkdownConfig(
+        resolveEmojiShortcode: _noopEmojiShortcode,
+        unicodeEmojiUrlBuilder: _noopUnicodeEmojiUrl,
+        customEmojiUrlBuilder: _noopCustomEmojiUrl,
+        internalLinkPattern: _internalFluxerLinkPattern,
+        linkWidgetBuilder: (_, _, _) => const Text('jump pill'),
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: FluxerMarkdown(data: url, config: config),
+          ),
+        ),
+      );
+
+      expect(find.text('jump pill'), findsOneWidget);
     });
 
     testWidgets('uses configured blockquote divider and text colors', (


### PR DESCRIPTION
# What this PR solves/adds

Resolves #114.

The code overrode masked links for channel and message links. Plain variants go through another path, so the fix here is to simply remove the widget logic.

<details><summary>Evidence</summary>

<img width="201" height="437" alt="image" src="https://github.com/user-attachments/assets/8db330b5-6bba-47f8-892b-f2bd1633724a" />

</details> 

## PR type

- [ ] Feature
- [x] Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Feature requirements

- GitHub Discussion link: N/A
- Visual proof (screenshot or video): N/A

## Validation

- [x] I explained what this PR solves or adds.
- [x] I verified the changes locally.
- [x] I completed all required feature items, or marked them as `N/A` if not applicable.

## Release Notes

- Fixed masked links showing content for message links and channel links
