### PR TITLE
ci: remove analyse path requirement

### DIFF
--- a/.github/workflows/dart-analyze.yml
+++ b/.github/workflows/dart-analyze.yml
@@ -14,8 +14,6 @@ on:
   pull_request:
     branches:
       - canary
-    paths:
-      - "**/*.dart"
 
 jobs:
   analyze:


### PR DESCRIPTION
# What this PR solves/adds

Having a required workflow that performs conditionally is a contradiction (this will block pull requests that do not satisfy the filter). Example: #371.

Since the workflow is required, the easy fix is to let it always run. The alternative fix is to not make the workflow required, which seems undesirable.

## PR type

- [ ] Feature
- [ ] Fix
- [ ] Refactor
- [ ] Documentation
- [x] Other

## Feature requirements

- GitHub Discussion link: N/A
- Visual proof (screenshot or video): N/A

## Validation

- [x] I explained what this PR solves or adds.
- [x] I verified the changes locally.
- [x] I completed all required feature items, or marked them as `N/A` if not applicable.

## Release Notes

- N/A