### PR TITLE
fix: only hide unfurled media when message is a single link

### DIFF
--- a/lib/features/chat/domain/message.dart
+++ b/lib/features/chat/domain/message.dart
@@ -1052,6 +1052,9 @@ class Message {
       return false;
     }
     final trimmed = content.trim();
+    if (trimmed.contains(RegExp(r'\s'))) {
+      return false;
+    }
     return Uri.tryParse(trimmed)?.hasAbsolutePath ?? false;
   }
 


### PR DESCRIPTION
# What this PR solves/adds

The presence of something else should be checked before hiding here:

https://github.com/fluxerapp/flutter_client/blob/b771bf1ae35b77f1d03600ee4984d9594a270628/lib/features/chat/domain/message.dart#L1044-L1056

Resolves #378.

## PR type

- [ ] Feature
- [x] Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Feature requirements

- GitHub Discussion link: N/A
- Visual proof (screenshot or video): N/A

## Validation

- [x] I explained what this PR solves or adds.
- [x] I verified the changes locally.
- [x] I completed all required feature items, or marked them as `N/A` if not applicable.

## Release Notes

- Revealed text in links with unfurled media
