### PR TITLE
fix: `flutter analyze` errors

### DIFF
--- a/lib/core/push/services/firebase_messaging_push_service.stub.dart
+++ b/lib/core/push/services/firebase_messaging_push_service.stub.dart
@@ -12,6 +12,8 @@ class FirebaseMessagingPushService implements PushService {
 
   static Future<void> bootstrapAfterAuth() async {}
 
+  static Stream<String> get tokenRefreshStream => const Stream<String>.empty();
+
   @override
   Future<void> requestPermissions() async {}
 

--- a/lib/features/chat/presentation/widgets/channel/channel_attachment_area.dart
+++ b/lib/features/chat/presentation/widgets/channel/channel_attachment_area.dart
@@ -37,7 +37,7 @@ class ChannelAttachmentArea extends ConsumerWidget {
             padding: const EdgeInsets.symmetric(horizontal: 8),
             buildDefaultDragHandles: false,
             itemCount: attachments.length,
-            onReorder: (int oldIndex, int newIndex) {
+            onReorderItem: (int oldIndex, int newIndex) {
               ref
                   .read(cloudUploadControllerProvider(channelId).notifier)
                   .reorderAttachments(oldIndex, newIndex);

--- a/lib/features/chat/providers/upload/cloud_upload_controller.dart
+++ b/lib/features/chat/providers/upload/cloud_upload_controller.dart
@@ -459,18 +459,14 @@ class CloudUploadController extends _$CloudUploadController {
     if (oldIndex < 0 ||
         oldIndex >= state.items.length ||
         newIndex < 0 ||
-        newIndex > state.items.length) {
+        newIndex >= state.items.length) {
       return;
-    }
-    var adjustedNewIndex = newIndex;
-    if (oldIndex < adjustedNewIndex) {
-      adjustedNewIndex -= 1;
     }
     final List<PendingAttachment> next = List<PendingAttachment>.from(
       state.items,
     );
     final PendingAttachment item = next.removeAt(oldIndex);
-    next.insert(adjustedNewIndex, item);
+    next.insert(newIndex, item);
     state = CloudComposerAttachments(next);
   }
 

--- a/lib/features/favorites/presentation/widgets/favorites_channel_list.dart
+++ b/lib/features/favorites/presentation/widgets/favorites_channel_list.dart
@@ -164,13 +164,9 @@ class FavoritesChannelList extends ConsumerWidget {
     required int oldIndex,
     required int newIndex,
   }) async {
-    var targetIndex = newIndex;
-    if (targetIndex > oldIndex) {
-      targetIndex -= 1;
-    }
     final reordered = List<ResolvedFavoriteEntry>.from(visibleEntries);
     final moved = reordered.removeAt(oldIndex);
-    reordered.insert(targetIndex, moved);
+    reordered.insert(newIndex, moved);
     final repository = ref.read(favoriteChannelsRepositoryProvider);
     for (var i = 0; i < reordered.length; i++) {
       await repository.moveChannel(
@@ -255,7 +251,7 @@ class _FavoriteGroupEntries extends ConsumerWidget {
       physics: const NeverScrollableScrollPhysics(),
       buildDefaultDragHandles: false,
       itemCount: entries.length,
-      onReorder: (oldIndex, newIndex) {
+      onReorderItem: (oldIndex, newIndex) {
         unawaited(
           FavoritesChannelList._reorderEntriesStatic(
             ref,

--- a/lib/features/settings/presentation/widgets/user_connections.dart
+++ b/lib/features/settings/presentation/widgets/user_connections.dart
@@ -263,7 +263,7 @@ class _ConnectionList extends ConsumerWidget {
       },
       proxyDecorator: (child, index, animation) =>
           Material(color: Colors.transparent, elevation: 4, child: child),
-      onReorder: (oldIndex, newIndex) async {
+      onReorderItem: (oldIndex, newIndex) async {
         try {
           await ref
               .read(connectionsViewModelProvider.notifier)

--- a/lib/features/settings/providers/connections_view_model.dart
+++ b/lib/features/settings/providers/connections_view_model.dart
@@ -91,12 +91,11 @@ class ConnectionsViewModel extends _$ConnectionsViewModel {
     if (oldIndex < 0 ||
         oldIndex >= current.length ||
         newIndex < 0 ||
-        newIndex > current.length) {
+        newIndex >= current.length) {
       return;
     }
-    final adjusted = newIndex > oldIndex ? newIndex - 1 : newIndex;
     final item = current.removeAt(oldIndex);
-    current.insert(adjusted, item);
+    current.insert(newIndex, item);
     final previous = state.connections;
     state = state.copyWith(connections: current);
 

--- a/lib/features/ui/accordion/fluxer_accordion.dart
+++ b/lib/features/ui/accordion/fluxer_accordion.dart
@@ -104,7 +104,7 @@ class _FluxerAccordionState extends State<FluxerAccordion>
         ),
         SizeTransition(
           sizeFactor: _sizeFactor,
-          axisAlignment: -1,
+          alignment: AlignmentDirectional.topStart,
           child: widget.child,
         ),
       ],

--- a/test/features/ui/form_controls_test.dart
+++ b/test/features/ui/form_controls_test.dart
@@ -1,3 +1,5 @@
+import 'dart:ui' show CheckedState, Tristate;
+
 import 'package:flutter/material.dart';
 import 'package:flutter/semantics.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -213,11 +215,7 @@ void main() {
     testWidgets('checkbox exposes checked state', (tester) async {
       await tester.pumpWidget(
         buildTestApp(
-          FluxerCheckbox(
-            value: true,
-            onChanged: (_) {},
-            label: 'Accept terms',
-          ),
+          FluxerCheckbox(value: true, onChanged: (_) {}, label: 'Accept terms'),
         ),
       );
 
@@ -225,7 +223,7 @@ void main() {
       final SemanticsNode node = tester.getSemantics(
         find.bySemanticsLabel('Accept terms'),
       );
-      expect(node.hasFlag(SemanticsFlag.isChecked), isTrue);
+      expect(node.flagsCollection.isChecked, CheckedState.isTrue);
     });
 
     testWidgets('radio group exposes selected option', (tester) async {
@@ -243,7 +241,7 @@ void main() {
       );
 
       final SemanticsNode beta = tester.getSemantics(find.text('Beta'));
-      expect(beta.hasFlag(SemanticsFlag.isChecked), isTrue);
+      expect(beta.flagsCollection.isChecked, CheckedState.isTrue);
     });
 
     testWidgets('toggle switch exposes toggled state', (tester) async {
@@ -261,8 +259,8 @@ void main() {
       final SemanticsNode node = tester.getSemantics(
         find.bySemanticsLabel('Enable notifications'),
       );
-      expect(node.hasFlag(SemanticsFlag.hasToggledState), isTrue);
-      expect(node.hasFlag(SemanticsFlag.isToggled), isTrue);
+      expect(node.flagsCollection.isToggled, isNot(Tristate.none));
+      expect(node.flagsCollection.isToggled, Tristate.isTrue);
     });
   });
 }


### PR DESCRIPTION
# What this PR solves/adds

Fixed `flutter analyze` errors reported by the CI:

```
2026-06-20T18:21:14.9152788Z   error • The getter 'tokenRefreshStream' isn't defined for the type 'FirebaseMessagingPushService'. Try importing the library that defines 'tokenRefreshStream', correcting the name to the name of an existing getter, or defining a getter or field named 'tokenRefreshStream' • 
```

Also fixed unrelated stuff reported (mostly deprecated stuff). Worth calling out `onReorderItem` handles index adjustments.

Unblocks #382.

## PR type

- [ ] Feature
- [x] Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Feature requirements

- GitHub Discussion link: N/A
- Visual proof (screenshot or video): N/A

## Validation

- [x] I explained what this PR solves or adds.
- [x] I verified the changes locally.
- [x] I completed all required feature items, or marked them as `N/A` if not applicable.

## Release Notes

- N/A
