### PR TITLE
fix: consistent profile display name and FluxerTag

### DIFF
--- a/lib/features/chat/presentation/sheets/channel_details_sheet.dart
+++ b/lib/features/chat/presentation/sheets/channel_details_sheet.dart
@@ -3341,13 +3341,7 @@ String? _detailsSubtitle({
     if (dm.isGroup) {
       return 'Group DM · ${dm.memberCount} members';
     }
-    final username = dm.recipientUsername;
-    if (username != null &&
-        username.isNotEmpty &&
-        username != dm.recipientName) {
-      return '@$username';
-    }
-    return dm.isSystem ? 'System message' : null;
+    return dm.recipientTag ?? (dm.isSystem ? 'System message' : null);
   }
   if (channel != null) {
     return switch (channel.type) {

--- a/lib/features/dm/domain/dm_conversation.dart
+++ b/lib/features/dm/domain/dm_conversation.dart
@@ -15,6 +15,7 @@ class DmConversation {
   final String recipientId;
   final String recipientName;
   final String? recipientUsername;
+  final String? recipientDiscriminator;
   final String? recipientAvatar;
   final String recipientStatus;
   final String? name;
@@ -42,6 +43,7 @@ class DmConversation {
     required this.lastMessage,
     required this.lastMessageTime,
     this.recipientUsername,
+    this.recipientDiscriminator,
     this.lastMessageAuthorId,
     this.lastMessageAuthorName,
     this.name,
@@ -71,6 +73,16 @@ class DmConversation {
     return recipientName;
   }
 
+  String? get recipientTag {
+    if (recipientUsername == null || recipientUsername!.isEmpty) {
+      return null;
+    }
+    if (recipientDiscriminator == null || recipientDiscriminator!.isEmpty) {
+      return recipientUsername;
+    }
+    return '$recipientUsername#$recipientDiscriminator';
+  }
+
   int get memberCount => recipientCount;
 
   factory DmConversation.fromRow(
@@ -89,6 +101,7 @@ class DmConversation {
       recipientId: row.recipientId,
       recipientName: recipient?.globalName ?? recipient?.username ?? 'Unknown',
       recipientUsername: recipient?.username,
+      recipientDiscriminator: recipient?.discriminator,
       recipientAvatar: recipient?.avatar,
       recipientStatus: recipient?.status ?? 'offline',
       name: row.name,

--- a/lib/features/profile/presentation/widgets/user_profile_header.dart
+++ b/lib/features/profile/presentation/widgets/user_profile_header.dart
@@ -41,7 +41,6 @@ class UserProfileHeader extends StatelessWidget {
     final colors = context.colors;
     final textStyles = context.textStyles;
     final layout = context.layout;
-    final isUsernameAsDisplay = displayName == username;
     final String? pronounsTrimmed = pronouns?.trim();
     final bool showPronouns =
         pronounsTrimmed != null && pronounsTrimmed.isNotEmpty;
@@ -65,15 +64,6 @@ class UserProfileHeader extends StatelessWidget {
               ),
             ),
             if (showUserTag) FluxerUserTag(isSystem: isSystem),
-            if (showUsername && isUsernameAsDisplay)
-              Text(
-                '#$discriminator',
-                style: textStyles.heading.copyWith(
-                  color: colors.textTertiary,
-                  fontSize: 24,
-                  fontWeight: FontWeight.w500,
-                ),
-              ),
           ],
         ),
         if (showUsername) ...[
@@ -83,14 +73,13 @@ class UserProfileHeader extends StatelessWidget {
             spacing: 6,
             runSpacing: 4,
             children: [
-              if (!isUsernameAsDisplay)
-                Text(
-                  '$username#$discriminator',
-                  style: textStyles.bodySmall.copyWith(
-                    color: colors.textTertiary,
-                    fontWeight: FontWeight.w500,
-                  ),
+              Text(
+                '$username#$discriminator',
+                style: textStyles.bodySmall.copyWith(
+                  color: colors.textTertiary,
+                  fontWeight: FontWeight.w500,
                 ),
+              ),
               UserProfileBadges(
                 flags: flags,
                 hasPlutonium: hasPlutonium,

--- a/test/features/profile/presentation/widgets/user_profile_header_test.dart
+++ b/test/features/profile/presentation/widgets/user_profile_header_test.dart
@@ -1,0 +1,61 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fluxer_app/core/theme/fluxer_layout_theme.dart';
+import 'package:fluxer_app/core/theme/fluxer_text_theme.dart';
+import 'package:fluxer_app/core/theme/fluxer_theme.dart';
+import 'package:fluxer_app/core/theme/themes/dark.dart';
+import 'package:fluxer_app/features/profile/presentation/widgets/user_profile_header.dart';
+
+Widget _buildApp(Widget child) {
+  final colorTheme = buildDarkColorTheme();
+  return MaterialApp(
+    theme: buildFluxerTheme(
+      colorTheme: colorTheme,
+      textTheme: FluxerTextTheme.fromColors(colorTheme),
+      layoutTheme: FluxerLayoutTheme.scaled(),
+    ),
+    home: Scaffold(body: child),
+  );
+}
+
+Widget _buildHeader(String displayName) {
+  return UserProfileHeader(
+    username: 'Jiralite',
+    discriminator: '0000',
+    displayName: displayName,
+    flags: 0,
+    hasPlutonium: false,
+    customStatus: null,
+  );
+}
+
+void main() {
+  group('UserProfileHeader', () {
+    testWidgets(
+      'uses resolved display name as title and username tag subtitle',
+      (tester) async {
+        for (final titleText in ['Jiralite Display', 'Jiralite']) {
+          await tester.pumpWidget(_buildApp(_buildHeader(titleText)));
+
+          final header = find.byType(UserProfileHeader);
+          final titleFinder = find.descendant(
+            of: header,
+            matching: find.text(titleText),
+          );
+          final tagFinder = find.descendant(
+            of: header,
+            matching: find.text('Jiralite#0000'),
+          );
+          final title = tester.widget<Text>(titleFinder);
+          final tag = tester.widget<Text>(tagFinder);
+
+          expect(header, findsOneWidget);
+          expect(titleFinder, findsOneWidget);
+          expect(title.style?.fontSize, 24);
+          expect(tagFinder, findsOneWidget);
+          expect(tag.style?.fontSize, isNot(24));
+        }
+      },
+    );
+  });
+}


### PR DESCRIPTION
# What this PR solves/adds

Display names and FluxerTags in profiles have been made consistent with desktop.

<details><summary>Evidence</summary>

<img width="1143" height="969" alt="image" src="https://github.com/user-attachments/assets/55f5d822-0f26-4cd4-9b68-30d5be82ceca" />

</details> 

- Resolves #365
- Resolves #366

## PR type

- [ ] Feature
- [x] Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Feature requirements

- GitHub Discussion link: N/A
- Visual proof (screenshot or video): N/A

## Validation

- [x] I explained what this PR solves or adds.
- [x] I verified the changes locally.
- [x] I completed all required feature items, or marked them as `N/A` if not applicable.

## Release Notes

- Fixed display names FluxerTags appearing in profiles
