### PR TITLE
fix: 1-minute TTL for profile caching

### DIFF
--- a/lib/shared/providers/user_profile.dart
+++ b/lib/shared/providers/user_profile.dart
@@ -11,6 +11,8 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'user_profile.g.dart';
 
+const Duration _userProfileCacheTtl = Duration(minutes: 1);
+
 class CurrentUserCachedProfile {
   const CurrentUserCachedProfile({
     required this.id,
@@ -54,16 +56,6 @@ Future<UserProfileFullResponse?> userProfile(
 
   final FluxerDatabase database = ref.read(fluxerDatabaseProvider);
   final User? cachedUser = await database.userDao.getUserById(resolvedId);
-  if (guildId == null && cachedUser != null) {
-    unawaited(
-      _refreshUserProfileFromNetwork(
-        ref,
-        userId: resolvedId,
-        guildId: guildId,
-      ),
-    );
-    return _userProfileFromCachedUser(cachedUser);
-  }
 
   final FluxerClient client = ref.read(fluxerClientProvider);
   try {
@@ -74,6 +66,7 @@ Future<UserProfileFullResponse?> userProfile(
       withMutualGuilds: 'true',
     );
     await _cacheUserProfile(database, profile);
+    _keepUserProfileAlive(ref);
     return profile;
   } on Object {
     if (cachedUser != null) {
@@ -81,6 +74,12 @@ Future<UserProfileFullResponse?> userProfile(
     }
     return null;
   }
+}
+
+void _keepUserProfileAlive(Ref ref) {
+  final keepAlive = ref.keepAlive();
+  final Timer timer = Timer(_userProfileCacheTtl, keepAlive.close);
+  ref.onDispose(timer.cancel);
 }
 
 UserProfileFullResponse _userProfileFromCachedUser(User user) {
@@ -122,29 +121,6 @@ Future<void> _cacheUserProfile(
       banner: Value(profile.userProfile.banner),
     ),
   );
-}
-
-Future<void> _refreshUserProfileFromNetwork(
-  Ref ref, {
-  required String userId,
-  String? guildId,
-}) async {
-  final FluxerClient client = ref.read(fluxerClientProvider);
-  final FluxerDatabase database = ref.read(fluxerDatabaseProvider);
-  try {
-    final UserProfileFullResponse profile = await client.users.getUserProfile(
-      targetId: userId,
-      guildId: guildId,
-      withMutualFriends: 'true',
-      withMutualGuilds: 'true',
-    );
-    await _cacheUserProfile(database, profile);
-    ref.invalidate(
-      userProfileProvider(userId: userId, guildId: guildId),
-    );
-  } on Object {
-    return;
-  }
 }
 
 // `AutoDisposeFutureProvider` is not exposed by the public API; the explicit


### PR DESCRIPTION
# What this PR solves/adds

The caching for profiles was removed for guilds in 9ceb7107bdd543e77921def86b9262734a16742a, but this still left direct messages with the bug.

Investigating further, it seems like this would not work at all. The code did this:

1. Fetch a cached profile
2. Fetch the full profile
3. Create a fake profile with the cached profile
4. Cached basic fields of the fetched full profile

This created a loop.

Instead of removing the caching system, I have opted for a 1-minute TTL. This preserves basic caching and fixes any bugs related to profile caching.

- Resolves #307
- Resolves #370

## PR type

- [ ] Feature
- [x] Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Feature requirements

- GitHub Discussion link: <!-- Required for feature PRs -->
- Visual proof (screenshot or video): <!-- Required for feature PRs -->

## Validation

- [x] I explained what this PR solves or adds.
- [x] I verified the changes locally.
- [x] I completed all required feature items, or marked them as `N/A` if not applicable.

## Release Notes

- Fixed user profiles not showing certain fields
