### PR TITLE
fix(user_settings_modal): allow scrolling to close unimplemented settings

### DIFF
--- a/lib/features/settings/presentation/user_settings_modal.dart
+++ b/lib/features/settings/presentation/user_settings_modal.dart
@@ -516,19 +516,32 @@ Widget _buildUserSettingsSectionContent({
     case UserSettingsSection.limitsConfig:
     case UserSettingsSection.featureFlags:
     case UserSettingsSection.whatsNew:
-      return _buildUserSettingsPlaceholder(context, section);
+      return _buildUserSettingsPlaceholder(
+        context,
+        section,
+        scrollController: scrollController,
+      );
   }
 }
 
 Widget _buildUserSettingsPlaceholder(
   BuildContext context,
-  UserSettingsSection section,
-) {
-  return Center(
+  UserSettingsSection section, {
+  ScrollController? scrollController,
+}) {
+  final child = Center(
     child: Text(
       userSettingsSectionLabel(FluxerLocalizations.of(context), section),
       style: TextStyle(color: context.colors.textPrimaryMuted, fontSize: 24),
     ),
+  );
+  if (scrollController == null) {
+    return child;
+  }
+  return CustomScrollView(
+    controller: scrollController,
+    physics: const AlwaysScrollableScrollPhysics(),
+    slivers: [SliverFillRemaining(hasScrollBody: false, child: child)],
   );
 }
 


### PR DESCRIPTION
# What this PR solves/adds

Previously, you had to tap the top area of your device to exit an unimplemented settings view. Now, you can scroll too.

## PR type

- [ ] Feature
- [x] Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Feature requirements

- GitHub Discussion link: N/A
- Visual proof (screenshot or video): N/A

## Validation

- [ ] I explained what this PR solves or adds.
- [x] I verified the changes locally.
- [ ] I completed all required feature items, or marked them as `N/A` if not applicable.

## Release Notes

- Fixed scrolling to close unimplemented settings
