### PR TITLE
fix: cluster group direct message icons everywhere

### DIFF
--- a/lib/features/chat/presentation/sheets/channel_details_sheet.dart
+++ b/lib/features/chat/presentation/sheets/channel_details_sheet.dart
@@ -32,6 +32,7 @@ import 'package:fluxer_app/features/chat/utils/composer_mention_query.dart';
 import 'package:fluxer_app/features/chat/utils/message_link.dart';
 import 'package:fluxer_app/features/dm/domain/dm_channel_types.dart';
 import 'package:fluxer_app/features/dm/domain/dm_conversation.dart';
+import 'package:fluxer_app/features/dm/presentation/widgets/group_dm_avatar.dart';
 import 'package:fluxer_app/features/dm/providers/dm_mute_provider.dart';
 import 'package:fluxer_app/features/dm/providers/dm_pinned_provider.dart';
 import 'package:fluxer_app/features/dm/providers/dm_providers.dart';
@@ -714,22 +715,10 @@ class _DetailsAvatar extends ConsumerWidget {
         );
       }
       if (dm.isGroup) {
-        return FluxerAvatarCluster(
-          channelId: dm.id,
-          iconUrl: FluxerMediaUrl.guildIcon(guildId: dm.id, hash: dm.icon),
-          status: dm.groupStatus,
+        return groupDmAvatarCluster(
+          dm: dm,
           size: _size,
-          members: [
-            for (final member in dm.groupMembers.take(3))
-              AvatarClusterMember(
-                userId: member.id,
-                fallbackText: member.name,
-                imageUrl: FluxerMediaUrl.userAvatar(
-                  userId: member.id,
-                  hash: member.avatar,
-                ),
-              ),
-          ],
+          status: dm.groupStatus,
         );
       }
       return FluxerAvatar.user(

--- a/lib/features/chat/presentation/widgets/channel/channel_header.dart
+++ b/lib/features/chat/presentation/widgets/channel/channel_header.dart
@@ -529,20 +529,43 @@ class ChannelHeader extends ConsumerWidget {
       return Stack(
         clipBehavior: Clip.none,
         children: <Widget>[
-          FluxerAvatar.user(
-            fallbackText: dm.recipientName,
-            userId: dm.recipientId,
-            imageUrl: FluxerMediaUrl.userAvatar(
+          if (dm.isGroup)
+            FluxerAvatarCluster(
+              channelId: dm.id,
+              iconUrl: FluxerMediaUrl.guildIcon(
+                guildId: dm.id,
+                hash: dm.icon,
+                animated: true,
+              ),
+              status: dm.groupStatus,
+              members: [
+                for (final member in dm.groupMembers.take(3))
+                  AvatarClusterMember(
+                    userId: member.id,
+                    imageUrl: FluxerMediaUrl.userAvatar(
+                      userId: member.id,
+                      hash: member.avatar,
+                    ),
+                    fallbackText: member.name,
+                  ),
+              ],
+              size: 32,
+            )
+          else
+            FluxerAvatar.user(
+              fallbackText: dm.recipientName,
               userId: dm.recipientId,
-              hash: dm.recipientAvatar,
-              animated: true,
+              imageUrl: FluxerMediaUrl.userAvatar(
+                userId: dm.recipientId,
+                hash: dm.recipientAvatar,
+                animated: true,
+              ),
+              status: shouldShowDmRecipientPresence(dm)
+                  ? dm.recipientStatus
+                  : null,
+              showStatus: shouldShowDmRecipientPresence(dm),
+              size: 32,
             ),
-            status: shouldShowDmRecipientPresence(dm)
-                ? dm.recipientStatus
-                : null,
-            showStatus: shouldShowDmRecipientPresence(dm),
-            size: 32,
-          ),
           if (showE2eeBadge)
             Positioned(
               right: -2,

--- a/lib/features/chat/presentation/widgets/channel/channel_header.dart
+++ b/lib/features/chat/presentation/widgets/channel/channel_header.dart
@@ -17,6 +17,7 @@ import 'package:fluxer_app/features/chat/presentation/sheets/channel_details_she
 import 'package:fluxer_app/features/chat/providers/core/chat_view_model.dart';
 import 'package:fluxer_app/features/dm/domain/dm_channel_types.dart';
 import 'package:fluxer_app/features/dm/domain/dm_conversation.dart';
+import 'package:fluxer_app/features/dm/presentation/widgets/group_dm_avatar.dart';
 import 'package:fluxer_app/features/dm/providers/dm_view_model.dart';
 import 'package:fluxer_app/features/favorites/domain/favorite_guild_id.dart';
 import 'package:fluxer_app/features/favorites/providers/favorite_channels_provider.dart';
@@ -530,27 +531,7 @@ class ChannelHeader extends ConsumerWidget {
         clipBehavior: Clip.none,
         children: <Widget>[
           if (dm.isGroup)
-            FluxerAvatarCluster(
-              channelId: dm.id,
-              iconUrl: FluxerMediaUrl.guildIcon(
-                guildId: dm.id,
-                hash: dm.icon,
-                animated: true,
-              ),
-              status: dm.groupStatus,
-              members: [
-                for (final member in dm.groupMembers.take(3))
-                  AvatarClusterMember(
-                    userId: member.id,
-                    imageUrl: FluxerMediaUrl.userAvatar(
-                      userId: member.id,
-                      hash: member.avatar,
-                    ),
-                    fallbackText: member.name,
-                  ),
-              ],
-              size: 32,
-            )
+            groupDmAvatarCluster(dm: dm, size: 32, status: dm.groupStatus)
           else
             FluxerAvatar.user(
               fallbackText: dm.recipientName,

--- a/lib/features/dm/presentation/widgets/dm_list.dart
+++ b/lib/features/dm/presentation/widgets/dm_list.dart
@@ -18,6 +18,7 @@ import 'package:fluxer_app/features/chat/providers/core/chat_providers.dart';
 import 'package:fluxer_app/features/chat/providers/core/chat_view_model.dart';
 import 'package:fluxer_app/features/dm/domain/dm_channel_types.dart';
 import 'package:fluxer_app/features/dm/domain/dm_conversation.dart';
+import 'package:fluxer_app/features/dm/presentation/widgets/group_dm_avatar.dart';
 import 'package:fluxer_app/features/dm/providers/dm_list_presence_provider.dart';
 import 'package:fluxer_app/features/dm/providers/dm_mute_provider.dart';
 import 'package:fluxer_app/features/dm/providers/dm_pinned_provider.dart';
@@ -745,19 +746,14 @@ class _DMListState extends ConsumerState<DMList> {
                     ),
                   ),
                 if (c.isGroup)
-                  FluxerAvatarCluster(
-                    channelId: c.id,
-                    iconUrl: FluxerMediaUrl.guildIcon(
-                      guildId: c.id,
-                      hash: c.icon,
-                    ),
+                  groupDmAvatarCluster(
+                    dm: c,
+                    size: avatarSize,
                     status: groupDmAggregateStatus(
                       participantIds: c.remoteRecipientIds,
                       resolveStatus: (String id) =>
                           presenceByUserId[id] ?? 'offline',
                     ),
-                    members: _clusterMembers(c),
-                    size: avatarSize,
                   )
                 else
                   FluxerAvatar.user(
@@ -1359,19 +1355,6 @@ class _DMListState extends ConsumerState<DMList> {
       ),
     ),
   );
-}
-
-List<AvatarClusterMember> _clusterMembers(DmConversation convo) {
-  return convo.groupMembers
-      .take(3)
-      .map(
-        (m) => AvatarClusterMember(
-          userId: m.id,
-          imageUrl: FluxerMediaUrl.userAvatar(userId: m.id, hash: m.avatar),
-          fallbackText: m.name,
-        ),
-      )
-      .toList();
 }
 
 enum _DmAction {

--- a/lib/features/dm/presentation/widgets/group_dm_avatar.dart
+++ b/lib/features/dm/presentation/widgets/group_dm_avatar.dart
@@ -1,0 +1,31 @@
+import 'package:fluxer_app/core/media/fluxer_media_url.dart';
+import 'package:fluxer_app/features/dm/domain/dm_conversation.dart';
+import 'package:fluxer_app/features/ui/avatar/fluxer_avatar_cluster.dart';
+
+List<AvatarClusterMember> groupDmClusterMembers(List<GroupMemberInfo> members) {
+  return <AvatarClusterMember>[
+    for (final GroupMemberInfo member in members.take(3))
+      AvatarClusterMember(
+        userId: member.id,
+        fallbackText: member.name,
+        imageUrl: FluxerMediaUrl.userAvatar(
+          userId: member.id,
+          hash: member.avatar,
+        ),
+      ),
+  ];
+}
+
+FluxerAvatarCluster groupDmAvatarCluster({
+  required DmConversation dm,
+  required double size,
+  required String? status,
+}) {
+  return FluxerAvatarCluster(
+    channelId: dm.id,
+    iconUrl: FluxerMediaUrl.guildIcon(guildId: dm.id, hash: dm.icon),
+    status: status,
+    members: groupDmClusterMembers(dm.groupMembers),
+    size: size,
+  );
+}

--- a/lib/features/favorites/presentation/widgets/favorites_channel_list.dart
+++ b/lib/features/favorites/presentation/widgets/favorites_channel_list.dart
@@ -12,6 +12,7 @@ import 'package:fluxer_app/features/channels/presentation/widgets/channel_icon.d
 import 'package:fluxer_app/features/channels/presentation/widgets/channel_unread_indicator.dart';
 import 'package:fluxer_app/features/channels/providers/channel_mute_provider.dart';
 import 'package:fluxer_app/features/channels/providers/unread_provider.dart';
+import 'package:fluxer_app/features/dm/presentation/widgets/group_dm_avatar.dart';
 import 'package:fluxer_app/features/favorites/domain/resolved_favorite_entry.dart';
 import 'package:fluxer_app/features/favorites/presentation/widgets/favorites_channel_context_menu.dart';
 import 'package:fluxer_app/features/favorites/presentation/widgets/favorites_list_context_menu.dart';
@@ -439,24 +440,7 @@ class _FavoriteLeadingIcon extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final dm = entry.dm;
     if (dm != null && dm.isGroup) {
-      return FluxerAvatarCluster(
-        channelId: dm.id,
-        iconUrl: dm.icon == null
-            ? null
-            : FluxerMediaUrl.guildIcon(guildId: dm.id, hash: dm.icon),
-        members: [
-          for (final member in dm.groupMembers.take(3))
-            AvatarClusterMember(
-              userId: member.id,
-              imageUrl: FluxerMediaUrl.userAvatar(
-                userId: member.id,
-                hash: member.avatar,
-              ),
-              fallbackText: member.name,
-            ),
-        ],
-        size: _avatarSize,
-      );
+      return groupDmAvatarCluster(dm: dm, size: _avatarSize, status: null);
     }
     if (dm != null) {
       return FluxerAvatar.user(

--- a/lib/features/quick_switcher/presentation/widgets/quick_switcher_result_row.dart
+++ b/lib/features/quick_switcher/presentation/widgets/quick_switcher_result_row.dart
@@ -3,7 +3,7 @@ import 'package:fluxer_app/core/media/fluxer_media_url.dart';
 import 'package:fluxer_app/core/theme/fluxer_theme_extension.dart';
 import 'package:fluxer_app/features/channels/domain/channel.dart';
 import 'package:fluxer_app/features/channels/presentation/widgets/channel_icon.dart';
-import 'package:fluxer_app/features/dm/domain/dm_conversation.dart';
+import 'package:fluxer_app/features/dm/presentation/widgets/group_dm_avatar.dart';
 import 'package:fluxer_app/features/quick_switcher/domain/quick_switcher_result_unread_state.dart';
 import 'package:fluxer_app/features/quick_switcher/domain/quick_switcher_types.dart';
 import 'package:fluxer_app/features/ui/ui.dart';
@@ -96,19 +96,7 @@ class QuickSwitcherResultRow extends StatelessWidget {
                   ? FluxerMediaUrl.guildIcon(guildId: channelId, hash: icon)
                   : null,
               status: groupStatus,
-              members: groupMembers
-                  .take(3)
-                  .map(
-                    (GroupMemberInfo member) => AvatarClusterMember(
-                      userId: member.id,
-                      imageUrl: FluxerMediaUrl.userAvatar(
-                        userId: member.id,
-                        hash: member.avatar,
-                      ),
-                      fallbackText: member.name,
-                    ),
-                  )
-                  .toList(),
+              members: groupDmClusterMembers(groupMembers),
             ),
           QuickSwitcherTextChannelResult() => ChannelIcon(
             type: ChannelType.text,

--- a/lib/features/voice/presentation/widgets/incoming_voice_call_sheet.dart
+++ b/lib/features/voice/presentation/widgets/incoming_voice_call_sheet.dart
@@ -5,9 +5,9 @@ import 'package:fluxer_app/core/theme/fluxer_theme_extension.dart';
 import 'package:fluxer_app/features/channels/domain/channel.dart';
 import 'package:fluxer_app/features/channels/providers/channel_providers.dart';
 import 'package:fluxer_app/features/dm/domain/dm_conversation.dart';
+import 'package:fluxer_app/features/dm/presentation/widgets/group_dm_avatar.dart';
 import 'package:fluxer_app/features/dm/providers/dm_view_model.dart';
 import 'package:fluxer_app/features/ui/avatar/fluxer_avatar.dart';
-import 'package:fluxer_app/features/ui/avatar/fluxer_avatar_cluster.dart';
 import 'package:fluxer_app/features/ui/bottom_sheet/fluxer_bottom_sheet.dart';
 import 'package:fluxer_app/l10n/generated/fluxer_localizations.dart';
 import 'package:fluxer_app/shared/utils/chat_context_utils.dart';
@@ -16,19 +16,6 @@ import 'package:phosphor_flutter/phosphor_flutter.dart';
 const String kIncomingVoiceResultAccept = 'accept';
 const String kIncomingVoiceResultReject = 'reject';
 const String kIncomingVoiceResultIgnore = 'ignore';
-
-List<AvatarClusterMember> _clusterMembers(DmConversation convo) {
-  return convo.groupMembers
-      .take(3)
-      .map(
-        (GroupMemberInfo m) => AvatarClusterMember(
-          userId: m.id,
-          imageUrl: FluxerMediaUrl.userAvatar(userId: m.id, hash: m.avatar),
-          fallbackText: m.name,
-        ),
-      )
-      .toList();
-}
 
 String _resolveSheetHeaderTitle({
   required DmConversation? dm,
@@ -203,13 +190,7 @@ class _IncomingVoiceCallSheetBody extends ConsumerWidget {
   Widget _buildAvatar(BuildContext context, {required DmConversation? dm}) {
     const double size = 80;
     if (dm != null && dm.isGroup) {
-      return FluxerAvatarCluster(
-        channelId: dm.id,
-        iconUrl: FluxerMediaUrl.guildIcon(guildId: dm.id, hash: dm.icon),
-        status: dm.groupStatus,
-        members: _clusterMembers(dm),
-        size: size,
-      );
+      return groupDmAvatarCluster(dm: dm, size: size, status: dm.groupStatus);
     }
     if (dm != null) {
       return FluxerAvatar.user(


### PR DESCRIPTION
# What this PR solves/adds

When a group direct message channel has no icon, it uses clusters. It already used clusters in the direct message list, but not everywhere else. This has been fixed everywhere.

Included in this fix is deduplication of the rendering and logic.

<details><summary>Evidence</summary>

<img width="201" height="187" alt="image" src="https://github.com/user-attachments/assets/d7121aa8-9192-421d-92dc-a45725288606" />

</details> 

## PR type

- [ ] Feature
- [x] Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Feature requirements

- GitHub Discussion link: N/A
- Visual proof (screenshot or video): N/A

## Validation

- [x] I explained what this PR solves or adds.
- [x] I verified the changes locally.
- [x] I completed all required feature items, or marked them as `N/A` if not applicable.

## Release Notes

- Fixed group direct messages icon clustering everywhere