### PR TITLE
chore: add DCO sign-off and AGPLv3 App Store exception

### DIFF
--- a/.github/dco.yml
+++ b/.github/dco.yml
@@ -1,0 +1,13 @@
+# Configuration for the DCO check (cncf/dco2): https://github.com/cncf/dco2
+# Requires a Developer Certificate of Origin sign-off (a "Signed-off-by" trailer)
+# on every commit in a pull request. See the DCO file and CONTRIBUTING.md.
+
+require:
+  # Require sign-off from organisation members too, so every commit carries the
+  # inbound-licence attestation. Set to false to exempt org members.
+  members: true
+
+allowRemediationCommits:
+  # Let a contributor retroactively sign off their own earlier commits.
+  individual: true
+  thirdParty: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,6 +6,7 @@ Describe the problem this pull request solves or the value it adds.
 
 - Link an issue (`Fixes #…`) or paste a [GitHub Discussion](https://github.com/orgs/fluxerapp/discussions) URL in this PR body.
 - All commits must be signed and verified on GitHub (GPG, SSH, or S/MIME).
+- All commits must be signed off under the [DCO](../DCO) (`git commit -s`), which is separate from the cryptographic signing above. See [CONTRIBUTING.md](../CONTRIBUTING.md).
 - Maintainers may add the `no-issue` label when traceability does not apply (e.g. docs only or release automation).
 
 ## PR type
@@ -30,6 +31,7 @@ If this PR is not a feature, write `N/A` for both items.
 - [ ] I explained what this PR solves or adds.
 - [ ] I verified the changes locally.
 - [ ] I completed all required feature items, or marked them as `N/A` if not applicable.
+- [ ] All my commits are signed off under the DCO (`git commit -s`).
 
 ## Release Notes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,58 @@
+# Contributing to Fluxer Mobile
+
+Thanks for your interest in contributing. Please read this before opening a pull
+request.
+
+## Scope during beta
+
+During the current beta we only accept contributions for **bug fixes**, and a pull
+request must be for a linked, reported issue. App translations are handled through
+our Weblate instance (see the [README](./README.md)). These guidelines will be
+expanded after the beta.
+
+Pull requests should target the `canary` branch. For local testing, use the
+`canary` build flavor so your build matches that branch.
+
+## Licensing of contributions
+
+This project is licensed under the GNU Affero General Public License, version 3
+(AGPLv3, see [`LICENSE`](./LICENSE)) **together with an App Store additional
+permission** under section 7 of the AGPLv3 (see
+[`LICENSE-APPSTORE-EXCEPTION`](./LICENSE-APPSTORE-EXCEPTION)).
+
+By submitting a contribution to this repository, you agree that your contribution
+is licensed under **the AGPLv3 together with the App Store additional permission in
+`LICENSE-APPSTORE-EXCEPTION`**, on the same terms as the rest of the project. This
+lets Fluxer distribute the app through application stores (such as the Apple App
+Store and Google Play) without changing the project's public AGPLv3 licensing. You
+keep the copyright in your contribution.
+
+There is **no separate or signed Contributor License Agreement**. Agreement to the
+above is given by the act of contributing, together with the DCO sign-off below.
+
+## Developer Certificate of Origin (DCO) sign-off
+
+Every commit must be signed off under the Developer Certificate of Origin (see the
+[`DCO`](./DCO) file). The sign-off is a single line at the end of each commit
+message:
+
+```
+Signed-off-by: Your Name <your.email@example.com>
+```
+
+Add it automatically with:
+
+```
+git commit -s
+```
+
+The name and email must be your real identity and match your committer details. If
+you forget, amend the last commit with `git commit --amend -s`, or sign off a whole
+branch with `git rebase --signoff <base>` and force-push.
+
+> The DCO sign-off (`-s`, a `Signed-off-by` line) is **separate from** the
+> cryptographic commit signing (`-S`, the GitHub "Verified" badge via GPG/SSH/S/MIME)
+> that this project also requires. Please do both.
+
+Pull requests are checked automatically by the [DCO app](https://github.com/cncf/dco2);
+a pull request cannot be merged until every commit is signed off.

--- a/DCO
+++ b/DCO
@@ -1,0 +1,34 @@
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.

--- a/LICENSE-APPSTORE-EXCEPTION
+++ b/LICENSE-APPSTORE-EXCEPTION
@@ -1,0 +1,31 @@
+Fluxer Mobile - App Store / application-store additional permission
+
+This file grants an additional permission under section 7 of the GNU Affero
+General Public License, version 3 (AGPLv3). It supplements, and does not
+replace, the AGPLv3 in the LICENSE file. The Program means the software in this
+repository.
+
+  As an additional permission under section 7 of the GNU Affero General Public
+  License, version 3, the copyright holders of the Program give you permission
+  to convey the Program, and any covered work based on it, through application
+  stores, app marketplaces, and similar distribution platforms (including,
+  without limitation, the Apple App Store and Google Play), and to enter into
+  and comply with those platforms' standard distribution and end-user terms,
+  notwithstanding the conditions of sections 6 and 10 of the License that would
+  otherwise prohibit conveying the work subject to such additional terms or
+  restrictions.
+
+  This additional permission applies only to distribution of the Program
+  through such platforms. It grants no further rights and waives no other
+  condition of the License, including the obligation in section 13 to offer the
+  Corresponding Source to users who interact with the Program over a network.
+  It does not prevent any recipient from also exercising their rights under the
+  unmodified AGPLv3.
+
+  As permitted by section 7, a recipient may remove this additional permission
+  from their own copy of the Program. Doing so does not affect any copy conveyed
+  by the copyright holders or by anyone else relying on this permission.
+
+By contributing to this repository you grant this same additional permission for
+your contribution, on the same terms as the rest of the Program. See
+CONTRIBUTING.md.

--- a/README.md
+++ b/README.md
@@ -125,6 +125,10 @@ After the beta period, we will be updating these guidelines.
 
 Pull requests should target the `canary` branch. For local testing, use the `canary` build flavor so your build matches that branch (see Mobile builds below).
 
+### Contribution licensing and sign-off
+
+By contributing you agree your contribution is licensed under the AGPLv3 together with the App Store additional permission (see [`LICENSE-APPSTORE-EXCEPTION`](./LICENSE-APPSTORE-EXCEPTION)), and you sign off each commit under the [Developer Certificate of Origin](./DCO) with `git commit -s`. There is no signed CLA. See [`CONTRIBUTING.md`](./CONTRIBUTING.md) for details; this is checked automatically on every pull request.
+
 ### Translating
 
 We welcome contributions for app translations. Translations are managed through our own Weblate instance. More information about that will be linked here soon.
@@ -178,3 +182,7 @@ Coming soon!
 ### API
 
 The Flutter client uses the [dart_sdk](https://github.com/fluxerapp/dart_sdk) to send requests to the Fluxer API which is generated from the OpenApi spec.
+
+## License
+
+Fluxer Mobile is licensed under the [GNU Affero General Public License v3](./LICENSE) (AGPLv3), together with an [App Store additional permission](./LICENSE-APPSTORE-EXCEPTION) under section 7 of the AGPLv3 that allows the app to be distributed through application stores (such as the Apple App Store and Google Play) without changing the project's public AGPLv3 licensing.


### PR DESCRIPTION
This PR sets up how contributions to the project are licensed. It adds a Developer Certificate of Origin (DCO) sign-off requirement. Every commit is signed off with `git commit -s`, and the cncf/dco2 check enforces this on pull requests, so each contribution is provably offered under our license without a signed CLA. It also adds an App Store additional permission under section 7 of the AGPLv3 (see `LICENSE-APPSTORE-EXCEPTION`). The project stays fully AGPLv3 with no terms changed. This one extra grant simply lets the app ship through Apple's App Store, whose DRM and usage terms would otherwise conflict with the (A)GPL. It also covers other stores such as Google Play as a precaution. Contributions are therefore licensed inbound under "AGPLv3 plus that permission," agreed by the act of contributing together with the DCO sign-off. Everything is wired through `CONTRIBUTING.md`, the `DCO` text, and `.github/dco.yml`, with short additions to the README and pull request template.