### PR TITLE
feat: Add guild scheduled events Flutter client

### DIFF
--- a/lib/core/router/route_names.dart
+++ b/lib/core/router/route_names.dart
@@ -24,6 +24,7 @@ abstract final class RouteNames {
   static const message = 'message';
   static const bookmarks = 'bookmarks';
   static const mentions = 'mentions';
+  static const guildCalendar = 'guild-calendar';
 
   // Deep links (outside shell)
   static const invite = 'invite';
@@ -57,6 +58,7 @@ abstract final class RoutePaths {
     String channelId,
     String messageId,
   ) => '/channels/$guildId/$channelId/$messageId';
+  static String guildCalendarPath(String guildId) => '/channels/$guildId/calendar';
   static String inviteLink(String code) => '/invite/$code';
   static String giftLink(String code) => '/gift/$code';
   static String themeLink(String themeId) => '/theme/$themeId';

--- a/lib/features/guild_scheduled_events/data/guild_scheduled_event_repository.dart
+++ b/lib/features/guild_scheduled_events/data/guild_scheduled_event_repository.dart
@@ -1,0 +1,168 @@
+import 'package:dio/dio.dart';
+import 'package:fluxer_app/features/guild_scheduled_events/domain/guild_scheduled_event.dart';
+import 'package:fluxer_dart/export.dart';
+
+class GuildScheduledEventRepository {
+  final FluxerClient _client;
+
+  const GuildScheduledEventRepository(this._client);
+
+  Future<List<GuildScheduledEvent>> listGuildScheduledEvents({
+    required String guildId,
+  }) async {
+    try {
+      final response = await _client.dio.get(
+        '/guilds/$guildId/scheduled-events',
+      );
+      final data = response.data as List;
+      return data
+          .map((json) => GuildScheduledEvent.fromJson(json as Map<String, dynamic>))
+          .toList();
+    } on DioException catch (e) {
+      throw Exception(e.response?.statusMessage ?? 'Failed to fetch scheduled events');
+    }
+  }
+
+  Future<GuildScheduledEvent?> getGuildScheduledEvent({
+    required String guildId,
+    required String eventId,
+  }) async {
+    try {
+      final response = await _client.dio.get(
+        '/guilds/$guildId/scheduled-events/$eventId',
+      );
+      if (response.statusCode == 404) return null;
+      return GuildScheduledEvent.fromJson(response.data as Map<String, dynamic>);
+    } on DioException catch (e) {
+      if (e.response?.statusCode == 404) return null;
+      throw Exception(e.response?.statusMessage ?? 'Failed to fetch scheduled event');
+    }
+  }
+
+  Future<GuildScheduledEvent> createGuildScheduledEvent({
+    required String guildId,
+    required String name,
+    String? description,
+    required DateTime scheduledStartTime,
+    DateTime? scheduledEndTime,
+    required int entityType,
+    String? entityId,
+    String? channelId,
+    String? location,
+  }) async {
+    try {
+      final response = await _client.dio.post(
+        '/guilds/$guildId/scheduled-events',
+        data: {
+          'name': name,
+          if (description != null) 'description': description,
+          'scheduled_start_time': scheduledStartTime.toUtc().toIso8601String(),
+          if (scheduledEndTime != null)
+            'scheduled_end_time': scheduledEndTime.toUtc().toIso8601String(),
+          'entity_type': entityType,
+          if (entityId != null) 'entity_id': entityId,
+          if (channelId != null) 'channel_id': channelId,
+          if (location != null) 'location': location,
+        },
+      );
+      return GuildScheduledEvent.fromJson(response.data as Map<String, dynamic>);
+    } on DioException catch (e) {
+      throw Exception(e.response?.statusMessage ?? 'Failed to create scheduled event');
+    }
+  }
+
+  Future<GuildScheduledEvent> updateGuildScheduledEvent({
+    required String guildId,
+    required String eventId,
+    String? name,
+    String? description,
+    DateTime? scheduledStartTime,
+    DateTime? scheduledEndTime,
+    int? entityType,
+    String? entityId,
+    String? channelId,
+    String? location,
+    int? status,
+  }) async {
+    try {
+      final response = await _client.dio.patch(
+        '/guilds/$guildId/scheduled-events/$eventId',
+        data: {
+          if (name != null) 'name': name,
+          if (description != null) 'description': description,
+          if (scheduledStartTime != null)
+            'scheduled_start_time': scheduledStartTime.toUtc().toIso8601String(),
+          if (scheduledEndTime != null)
+            'scheduled_end_time': scheduledEndTime.toUtc().toIso8601String(),
+          if (entityType != null) 'entity_type': entityType,
+          if (entityId != null) 'entity_id': entityId,
+          if (channelId != null) 'channel_id': channelId,
+          if (location != null) 'location': location,
+          if (status != null) 'status': status,
+        },
+      );
+      return GuildScheduledEvent.fromJson(response.data as Map<String, dynamic>);
+    } on DioException catch (e) {
+      throw Exception(e.response?.statusMessage ?? 'Failed to update scheduled event');
+    }
+  }
+
+  Future<void> deleteGuildScheduledEvent({
+    required String guildId,
+    required String eventId,
+  }) async {
+    try {
+      await _client.dio.delete('/guilds/$guildId/scheduled-events/$eventId');
+    } on DioException catch (e) {
+      throw Exception(e.response?.statusMessage ?? 'Failed to delete scheduled event');
+    }
+  }
+
+  Future<void> subscribeToEvent({
+    required String guildId,
+    required String eventId,
+  }) async {
+    try {
+      await _client.dio.put('/guilds/$guildId/scheduled-events/$eventId/subscribe');
+    } on DioException catch (e) {
+      throw Exception(e.response?.statusMessage ?? 'Failed to subscribe to event');
+    }
+  }
+
+  Future<void> unsubscribeFromEvent({
+    required String guildId,
+    required String eventId,
+  }) async {
+    try {
+      await _client.dio.delete('/guilds/$guildId/scheduled-events/$eventId/subscribe');
+    } on DioException catch (e) {
+      throw Exception(e.response?.statusMessage ?? 'Failed to unsubscribe from event');
+    }
+  }
+
+  Future<List<String>> listEventSubscribers({
+    required String guildId,
+    required String eventId,
+  }) async {
+    try {
+      final response = await _client.dio.get(
+        '/guilds/$guildId/scheduled-events/$eventId/subscribers',
+      );
+      return (response.data as List).cast<String>();
+    } on DioException catch (e) {
+      throw Exception(e.response?.statusMessage ?? 'Failed to fetch subscribers');
+    }
+  }
+
+  Future<List<GuildScheduledEvent>> listUserScheduledEvents() async {
+    try {
+      final response = await _client.dio.get('/users/@me/scheduled-events');
+      final data = response.data as List;
+      return data
+          .map((json) => GuildScheduledEvent.fromJson(json as Map<String, dynamic>))
+          .toList();
+    } on DioException catch (e) {
+      throw Exception(e.response?.statusMessage ?? 'Failed to fetch user scheduled events');
+    }
+  }
+}

--- a/lib/features/guild_scheduled_events/domain/guild_scheduled_event.dart
+++ b/lib/features/guild_scheduled_events/domain/guild_scheduled_event.dart
@@ -1,0 +1,90 @@
+class GuildScheduledEvent {
+  final String id;
+  final String guildId;
+  final String? channelId;
+  final String creatorId;
+  final String name;
+  final String? description;
+  final DateTime scheduledStartTime;
+  final DateTime? scheduledEndTime;
+  final int privacyLevel;
+  final int status;
+  final int entityType;
+  final String? entityId;
+  final String? location;
+  final String? image;
+  final DateTime createdAt;
+  final DateTime updatedAt;
+  final int version;
+  final int subscriberCount;
+
+  const GuildScheduledEvent({
+    required this.id,
+    required this.guildId,
+    this.channelId,
+    required this.creatorId,
+    required this.name,
+    this.description,
+    required this.scheduledStartTime,
+    this.scheduledEndTime,
+    required this.privacyLevel,
+    required this.status,
+    required this.entityType,
+    this.entityId,
+    this.location,
+    this.image,
+    required this.createdAt,
+    required this.updatedAt,
+    required this.version,
+    this.subscriberCount = 0,
+  });
+
+  factory GuildScheduledEvent.fromJson(Map<String, dynamic> json) {
+    return GuildScheduledEvent(
+      id: json['id'] as String,
+      guildId: json['guild_id'] as String,
+      channelId: json['channel_id'] as String?,
+      creatorId: json['creator_id'] as String,
+      name: json['name'] as String,
+      description: json['description'] as String?,
+      scheduledStartTime: DateTime.parse(json['scheduled_start_time'] as String),
+      scheduledEndTime: json['scheduled_end_time'] != null
+          ? DateTime.parse(json['scheduled_end_time'] as String)
+          : null,
+      privacyLevel: json['privacy_level'] as int,
+      status: json['status'] as int,
+      entityType: json['entity_type'] as int,
+      entityId: json['entity_id'] as String?,
+      location: json['location'] as String?,
+      image: json['image'] as String?,
+      createdAt: DateTime.parse(json['created_at'] as String),
+      updatedAt: DateTime.parse(json['updated_at'] as String),
+      version: json['version'] as int,
+      subscriberCount: json['subscriber_count'] as int? ?? 0,
+    );
+  }
+
+  bool get isScheduled => status == 0;
+  bool get isActive => status == 1;
+  bool get isCompleted => status == 2;
+  bool get isCancelled => status == 3;
+}
+
+enum GuildScheduledEventStatus {
+  scheduled(0),
+  active(1),
+  completed(2),
+  cancelled(3);
+
+  const GuildScheduledEventStatus(this.value);
+  final int value;
+}
+
+enum GuildScheduledEventEntityType {
+  stageInstance(1),
+  voice(2),
+  external(3);
+
+  const GuildScheduledEventEntityType(this.value);
+  final int value;
+}

--- a/lib/features/guild_scheduled_events/presentation/calendar_screen.dart
+++ b/lib/features/guild_scheduled_events/presentation/calendar_screen.dart
@@ -1,0 +1,364 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:fluxer_app/features/guild_scheduled_events/domain/guild_scheduled_event.dart';
+import 'package:fluxer_app/features/guild_scheduled_events/presentation/widgets/event_card.dart';
+import 'package:fluxer_app/features/guild_scheduled_events/presentation/widgets/create_event_dialog.dart';
+import 'package:go_router/go_router.dart';
+
+class CalendarScreen extends ConsumerStatefulWidget {
+  final String guildId;
+
+  const CalendarScreen({super.key, required this.guildId});
+
+  @override
+  ConsumerState<CalendarScreen> createState() => _CalendarScreenState();
+}
+
+class _CalendarScreenState extends ConsumerState<CalendarScreen> {
+  late DateTime _selectedDate;
+  late DateTime _currentMonth;
+
+  @override
+  void initState() {
+    super.initState();
+    _selectedDate = DateTime.now();
+    _currentMonth = DateTime(_selectedDate.year, _selectedDate.month);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Calendar'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.add),
+            onPressed: () => _showCreateEventDialog(context),
+          ),
+        ],
+      ),
+      body: Column(
+        children: [
+          _buildMonthSelector(),
+          _buildCalendarGrid(),
+          const Divider(),
+          Expanded(
+            child: _buildEventsList(),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildMonthSelector() {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          IconButton(
+            icon: const Icon(Icons.chevron_left),
+            onPressed: () {
+              setState(() {
+                _currentMonth = DateTime(_currentMonth.year, _currentMonth.month - 1);
+              });
+            },
+          ),
+          Text(
+            '${_getMonthName(_currentMonth.month)} ${_currentMonth.year}',
+            style: Theme.of(context).textTheme.titleLarge,
+          ),
+          IconButton(
+            icon: const Icon(Icons.chevron_right),
+            onPressed: () {
+              setState(() {
+                _currentMonth = DateTime(_currentMonth.year, _currentMonth.month + 1);
+              });
+            },
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildCalendarGrid() {
+    final firstDay = DateTime(_currentMonth.year, _currentMonth.month, 1);
+    final lastDay = DateTime(_currentMonth.year, _currentMonth.month + 1, 0);
+    final startWeekday = firstDay.weekday % 7;
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16),
+      child: Column(
+        children: [
+          Row(
+            children: ['S', 'M', 'T', 'W', 'T', 'F', 'S']
+                .map((day) => Expanded(
+                      child: Center(
+                        child: Text(
+                          day,
+                          style: Theme.of(context).textTheme.bodySmall,
+                        ),
+                      ),
+                    ))
+                .toList(),
+          ),
+          const SizedBox(height: 8),
+          GridView.builder(
+            shrinkWrap: true,
+            physics: const NeverScrollableScrollPhysics(),
+            gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+              crossAxisCount: 7,
+            ),
+            itemCount: startWeekday + lastDay.day,
+            itemBuilder: (context, index) {
+              if (index < startWeekday) {
+                return const SizedBox();
+              }
+              final day = index - startWeekday + 1;
+              final date = DateTime(_currentMonth.year, _currentMonth.month, day);
+              final isSelected = _isSameDay(date, _selectedDate);
+              final isToday = _isSameDay(date, DateTime.now());
+
+              return GestureDetector(
+                onTap: () {
+                  setState(() {
+                    _selectedDate = date;
+                  });
+                },
+                child: Container(
+                  margin: const EdgeInsets.all(2),
+                  decoration: BoxDecoration(
+                    color: isSelected
+                        ? Theme.of(context).colorScheme.primary
+                        : isToday
+                            ? Theme.of(context).colorScheme.primaryContainer
+                            : null,
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                  child: Center(
+                    child: Text(
+                      '$day',
+                      style: TextStyle(
+                        color: isSelected
+                            ? Theme.of(context).colorScheme.onPrimary
+                            : isToday
+                                ? Theme.of(context).colorScheme.onPrimaryContainer
+                                : null,
+                      ),
+                    ),
+                  ),
+                ),
+              );
+            },
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildEventsList() {
+    return Consumer(
+      builder: (context, ref, child) {
+        final eventsAsync = ref.watch(guildScheduledEventsProvider(widget.guildId));
+
+        if (eventsAsync.isEmpty) {
+          return const Center(
+            child: Text('No events scheduled'),
+          );
+        }
+
+        final dayEvents = eventsAsync.where((event) {
+          return _isSameDay(event.scheduledStartTime, _selectedDate);
+        }).toList();
+
+        if (dayEvents.isEmpty) {
+          return Center(
+            child: Text('No events on ${_formatDate(_selectedDate)}'),
+          );
+        }
+
+        return ListView.builder(
+          padding: const EdgeInsets.all(16),
+          itemCount: dayEvents.length,
+          itemBuilder: (context, index) {
+            return EventCard(
+              event: dayEvents[index],
+              onTap: () => _showEventDetail(context, dayEvents[index]),
+            );
+          },
+        );
+      },
+    );
+  }
+
+  void _showCreateEventDialog(BuildContext context) {
+    showDialog(
+      context: context,
+      builder: (context) => CreateEventDialog(guildId: widget.guildId),
+    );
+  }
+
+  void _showEventDetail(BuildContext context, GuildScheduledEvent event) {
+    showModalBottomSheet(
+      context: context,
+      isScrollControlled: true,
+      builder: (context) => _EventDetailSheet(event: event, guildId: widget.guildId),
+    );
+  }
+
+  bool _isSameDay(DateTime a, DateTime b) {
+    return a.year == b.year && a.month == b.month && a.day == b.day;
+  }
+
+  String _formatDate(DateTime date) {
+    return '${_getMonthName(date.month)} ${date.day}, ${date.year}';
+  }
+
+  String _getMonthName(int month) {
+    const months = [
+      'January', 'February', 'March', 'April', 'May', 'June',
+      'July', 'August', 'September', 'October', 'November', 'December',
+    ];
+    return months[month - 1];
+  }
+}
+
+class _EventDetailSheet extends ConsumerWidget {
+  final GuildScheduledEvent event;
+  final String guildId;
+
+  const _EventDetailSheet({required this.event, required this.guildId});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final subscription = ref.watch(
+      eventSubscriptionProvider(guildId: guildId, eventId: event.id),
+    );
+
+    return DraggableScrollableSheet(
+      initialChildSize: 0.7,
+      minChildSize: 0.5,
+      maxChildSize: 0.9,
+      expand: false,
+      builder: (context, scrollController) {
+        return Container(
+          padding: const EdgeInsets.all(16),
+          child: ListView(
+            controller: scrollController,
+            children: [
+              Center(
+                child: Container(
+                  width: 40,
+                  height: 4,
+                  margin: const EdgeInsets.only(bottom: 16),
+                  decoration: BoxDecoration(
+                    color: Theme.of(context).colorScheme.onSurfaceVariant.withOpacity(0.4),
+                    borderRadius: BorderRadius.circular(2),
+                  ),
+                ),
+              ),
+              Text(
+                event.name,
+                style: Theme.of(context).textTheme.headlineSmall,
+              ),
+              const SizedBox(height: 8),
+              _buildStatusChip(context),
+              const SizedBox(height: 16),
+              _buildInfoRow(
+                context,
+                icon: Icons.calendar_today,
+                label: _formatDateTime(event.scheduledStartTime),
+              ),
+              if (event.scheduledEndTime != null) ...[
+                const SizedBox(height: 8),
+                _buildInfoRow(
+                  context,
+                  icon: Icons.calendar_today,
+                  label: 'Until ${_formatDateTime(event.scheduledEndTime!)}',
+                ),
+              ],
+              if (event.location != null) ...[
+                const SizedBox(height: 8),
+                _buildInfoRow(
+                  context,
+                  icon: Icons.location_on,
+                  label: event.location!,
+                ),
+              ],
+              const SizedBox(height: 8),
+              _buildInfoRow(
+                context,
+                icon: Icons.people,
+                label: '${event.subscriberCount} going',
+              ),
+              if (event.description != null && event.description!.isNotEmpty) ...[
+                const SizedBox(height: 16),
+                Text(
+                  event.description!,
+                  style: Theme.of(context).textTheme.bodyLarge,
+                ),
+              ],
+              const SizedBox(height: 24),
+              SizedBox(
+                width: double.infinity,
+                child: ElevatedButton.icon(
+                  onPressed: () {
+                    ref.read(eventSubscriptionProvider(guildId: guildId, eventId: event.id).notifier).toggle();
+                  },
+                  icon: Icon(
+                    subscription ? Icons.check : Icons.add,
+                  ),
+                  label: Text(subscription ? "I'm Going" : 'Join Event'),
+                ),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _buildStatusChip(BuildContext context) {
+    Color color;
+    String label;
+
+    if (event.isActive) {
+      color = Colors.green;
+      label = 'In Progress';
+    } else if (event.isCompleted) {
+      color = Colors.grey;
+      label = 'Completed';
+    } else if (event.isCancelled) {
+      color = Colors.red;
+      label = 'Cancelled';
+    } else {
+      color = Colors.blue;
+      label = 'Upcoming';
+    }
+
+    return Chip(
+      label: Text(label),
+      backgroundColor: color.withOpacity(0.2),
+      labelStyle: TextStyle(color: color),
+    );
+  }
+
+  Widget _buildInfoRow(BuildContext context, {required IconData icon, required String label}) {
+    return Row(
+      children: [
+        Icon(icon, size: 16, color: Theme.of(context).colorScheme.onSurfaceVariant),
+        const SizedBox(width: 8),
+        Expanded(
+          child: Text(
+            label,
+            style: Theme.of(context).textTheme.bodyMedium,
+          ),
+        ),
+      ],
+    );
+  }
+
+  String _formatDateTime(DateTime dateTime) {
+    return '${dateTime.month}/${dateTime.day}/${dateTime.year} ${dateTime.hour}:${dateTime.minute.toString().padLeft(2, '0')}';
+  }
+}

--- a/lib/features/guild_scheduled_events/presentation/widgets/create_event_dialog.dart
+++ b/lib/features/guild_scheduled_events/presentation/widgets/create_event_dialog.dart
@@ -1,0 +1,273 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:fluxer_app/features/guild_scheduled_events/providers/guild_scheduled_event_providers.dart';
+
+class CreateEventDialog extends ConsumerStatefulWidget {
+  final String guildId;
+
+  const CreateEventDialog({super.key, required this.guildId});
+
+  @override
+  ConsumerState<CreateEventDialog> createState() => _CreateEventDialogState();
+}
+
+class _CreateEventDialogState extends ConsumerState<CreateEventDialog> {
+  final _formKey = GlobalKey<FormState>();
+  final _nameController = TextEditingController();
+  final _descriptionController = TextEditingController();
+  final _locationController = TextEditingController();
+  
+  DateTime _startDate = DateTime.now();
+  TimeOfDay _startTime = TimeOfDay.now();
+  DateTime? _endDate;
+  TimeOfDay? _endTime;
+  int _entityType = 3; // Default to external
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    _descriptionController.dispose();
+    _locationController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Dialog(
+      child: SingleChildScrollView(
+        padding: const EdgeInsets.all(24),
+        child: Form(
+          key: _formKey,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Text(
+                'Create Event',
+                style: Theme.of(context).textTheme.headlineSmall,
+              ),
+              const SizedBox(height: 24),
+              TextFormField(
+                controller: _nameController,
+                decoration: const InputDecoration(
+                  labelText: 'Event Name',
+                  hintText: 'Enter event name',
+                ),
+                validator: (value) {
+                  if (value == null || value.isEmpty) {
+                    return 'Please enter an event name';
+                  }
+                  return null;
+                },
+              ),
+              const SizedBox(height: 16),
+              TextFormField(
+                controller: _descriptionController,
+                decoration: const InputDecoration(
+                  labelText: 'Description (optional)',
+                  hintText: 'Enter event description',
+                ),
+                maxLines: 3,
+              ),
+              const SizedBox(height: 16),
+              TextFormField(
+                controller: _locationController,
+                decoration: const InputDecoration(
+                  labelText: 'Location (optional)',
+                  hintText: 'Enter event location',
+                ),
+              ),
+              const SizedBox(height: 24),
+              Text(
+                'Start Time',
+                style: Theme.of(context).textTheme.titleMedium,
+              ),
+              const SizedBox(height: 8),
+              Row(
+                children: [
+                  Expanded(
+                    child: OutlinedButton.icon(
+                      onPressed: _selectStartDate,
+                      icon: const Icon(Icons.calendar_today),
+                      label: Text(_formatDate(_startDate)),
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: OutlinedButton.icon(
+                      onPressed: _selectStartTime,
+                      icon: const Icon(Icons.access_time),
+                      label: Text(_startTime.format(context)),
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 16),
+              Row(
+                children: [
+                  Expanded(
+                    child: SwitchListTile(
+                      title: const Text('End Time'),
+                      value: _endDate != null,
+                      onChanged: (value) {
+                        setState(() {
+                          if (value) {
+                            _endDate = _startDate;
+                            _endTime = const TimeOfDay(hour: 23, minute: 59);
+                          } else {
+                            _endDate = null;
+                            _endTime = null;
+                          }
+                        });
+                      },
+                      contentPadding: EdgeInsets.zero,
+                    ),
+                  ),
+                ],
+              ),
+              if (_endDate != null) ...[
+                const SizedBox(height: 8),
+                Row(
+                  children: [
+                    Expanded(
+                      child: OutlinedButton.icon(
+                        onPressed: _selectEndDate,
+                        icon: const Icon(Icons.calendar_today),
+                        label: Text(_formatDate(_endDate!)),
+                      ),
+                    ),
+                    const SizedBox(width: 8),
+                    Expanded(
+                      child: OutlinedButton.icon(
+                        onPressed: _selectEndTime,
+                        icon: const Icon(Icons.access_time),
+                        label: Text(_endTime!.format(context)),
+                      ),
+                    ),
+                  ],
+                ),
+              ],
+              const SizedBox(height: 24),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.end,
+                children: [
+                  TextButton(
+                    onPressed: () => Navigator.of(context).pop(),
+                    child: const Text('Cancel'),
+                  ),
+                  const SizedBox(width: 8),
+                  ElevatedButton(
+                    onPressed: _submit,
+                    child: const Text('Create'),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Future<void> _selectStartDate() async {
+    final picked = await showDatePicker(
+      context: context,
+      initialDate: _startDate,
+      firstDate: DateTime.now(),
+      lastDate: DateTime.now().add(const Duration(days: 365)),
+    );
+    if (picked != null) {
+      setState(() {
+        _startDate = picked;
+        if (_endDate != null && _endDate!.isBefore(_startDate)) {
+          _endDate = _startDate;
+        }
+      });
+    }
+  }
+
+  Future<void> _selectStartTime() async {
+    final picked = await showTimePicker(
+      context: context,
+      initialTime: _startTime,
+    );
+    if (picked != null) {
+      setState(() {
+        _startTime = picked;
+      });
+    }
+  }
+
+  Future<void> _selectEndDate() async {
+    final picked = await showDatePicker(
+      context: context,
+      initialDate: _endDate ?? _startDate,
+      firstDate: _startDate,
+      lastDate: DateTime.now().add(const Duration(days: 365)),
+    );
+    if (picked != null) {
+      setState(() {
+        _endDate = picked;
+      });
+    }
+  }
+
+  Future<void> _selectEndTime() async {
+    final picked = await showTimePicker(
+      context: context,
+      initialTime: _endTime ?? const TimeOfDay(hour: 23, minute: 59),
+    );
+    if (picked != null) {
+      setState(() {
+        _endTime = picked;
+      });
+    }
+  }
+
+  Future<void> _submit() async {
+    if (!_formKey.currentState!.validate()) return;
+
+    final startDateTime = DateTime(
+      _startDate.year,
+      _startDate.month,
+      _startDate.day,
+      _startTime.hour,
+      _startTime.minute,
+    );
+
+    DateTime? endDateTime;
+    if (_endDate != null && _endTime != null) {
+      endDateTime = DateTime(
+        _endDate!.year,
+        _endDate!.month,
+        _endDate!.day,
+        _endTime!.hour,
+        _endTime!.minute,
+      );
+    }
+
+    final event = await ref.read(guildScheduledEventsProvider(widget.guildId).notifier).createEvent(
+      name: _nameController.text.trim(),
+      description: _descriptionController.text.trim().isEmpty
+          ? null
+          : _descriptionController.text.trim(),
+      scheduledStartTime: startDateTime,
+      scheduledEndTime: endDateTime,
+      entityType: _entityType,
+      location: _locationController.text.trim().isEmpty
+          ? null
+          : _locationController.text.trim(),
+    );
+
+    if (mounted && event != null) {
+      Navigator.of(context).pop();
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Event created successfully')),
+      );
+    }
+  }
+
+  String _formatDate(DateTime date) {
+    return '${date.month}/${date.day}/${date.year}';
+  }
+}

--- a/lib/features/guild_scheduled_events/presentation/widgets/event_card.dart
+++ b/lib/features/guild_scheduled_events/presentation/widgets/event_card.dart
@@ -1,0 +1,132 @@
+import 'package:flutter/material.dart';
+import 'package:fluxer_app/features/guild_scheduled_events/domain/guild_scheduled_event.dart';
+
+class EventCard extends StatelessWidget {
+  final GuildScheduledEvent event;
+  final VoidCallback? onTap;
+
+  const EventCard({
+    super.key,
+    required this.event,
+    this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      margin: const EdgeInsets.only(bottom: 8),
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(12),
+        child: Padding(
+          padding: const EdgeInsets.all(12),
+          child: Row(
+            children: [
+              _buildTimeBlock(context),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      event.name,
+                      style: Theme.of(context).textTheme.titleMedium,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                    const SizedBox(height: 4),
+                    if (event.location != null)
+                      Row(
+                        children: [
+                          Icon(
+                            Icons.location_on,
+                            size: 14,
+                            color: Theme.of(context).colorScheme.onSurfaceVariant,
+                          ),
+                          const SizedBox(width: 4),
+                          Expanded(
+                            child: Text(
+                              event.location!,
+                              style: Theme.of(context).textTheme.bodySmall,
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                            ),
+                          ),
+                        ],
+                      ),
+                    const SizedBox(height: 4),
+                    Row(
+                      children: [
+                        Icon(
+                          Icons.people,
+                          size: 14,
+                          color: Theme.of(context).colorScheme.onSurfaceVariant,
+                        ),
+                        const SizedBox(width: 4),
+                        Text(
+                          '${event.subscriberCount} going',
+                          style: Theme.of(context).textTheme.bodySmall,
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+              ),
+              _buildStatusIndicator(context),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildTimeBlock(BuildContext context) {
+    final hour = event.scheduledStartTime.hour;
+    final period = hour >= 12 ? 'PM' : 'AM';
+    final displayHour = hour > 12 ? hour - 12 : (hour == 0 ? 12 : hour);
+
+    return Container(
+      width: 56,
+      padding: const EdgeInsets.symmetric(vertical: 8),
+      decoration: BoxDecoration(
+        color: _getStatusColor().withOpacity(0.1),
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Column(
+        children: [
+          Text(
+            '$displayHour',
+            style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                  color: _getStatusColor(),
+                  fontWeight: FontWeight.bold,
+                ),
+          ),
+          Text(
+            period,
+            style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                  color: _getStatusColor(),
+                ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildStatusIndicator(BuildContext context) {
+    return Container(
+      width: 8,
+      height: 8,
+      decoration: BoxDecoration(
+        color: _getStatusColor(),
+        shape: BoxShape.circle,
+      ),
+    );
+  }
+
+  Color _getStatusColor() {
+    if (event.isActive) return Colors.green;
+    if (event.isCompleted) return Colors.grey;
+    if (event.isCancelled) return Colors.red;
+    return Colors.blue;
+  }
+}

--- a/lib/features/guild_scheduled_events/providers/guild_scheduled_event_providers.dart
+++ b/lib/features/guild_scheduled_events/providers/guild_scheduled_event_providers.dart
@@ -1,0 +1,134 @@
+import 'package:fluxer_app/core/api/fluxer_client_provider.dart';
+import 'package:fluxer_app/features/guild_scheduled_events/data/guild_scheduled_event_repository.dart';
+import 'package:fluxer_app/features/guild_scheduled_events/domain/guild_scheduled_event.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'guild_scheduled_event_providers.g.dart';
+
+@Riverpod(keepAlive: true)
+GuildScheduledEventRepository guildScheduledEventRepository(Ref ref) {
+  final client = ref.watch(fluxerClientProvider);
+  return GuildScheduledEventRepository(client);
+}
+
+@riverpod
+class GuildScheduledEvents extends _$GuildScheduledEvents {
+  @override
+  List<GuildScheduledEvent> build(String guildId) {
+    _fetchEvents();
+    return [];
+  }
+
+  Future<void> _fetchEvents() async {
+    final repo = ref.read(guildScheduledEventRepositoryProvider);
+    try {
+      final events = await repo.listGuildScheduledEvents(guildId: guildId);
+      state = events;
+    } catch (_) {}
+  }
+
+  Future<void> refresh() async {
+    final repo = ref.read(guildScheduledEventRepositoryProvider);
+    try {
+      final events = await repo.listGuildScheduledEvents(guildId: guildId);
+      state = events;
+    } catch (_) {}
+  }
+
+  Future<GuildScheduledEvent?> createEvent({
+    required String name,
+    String? description,
+    required DateTime scheduledStartTime,
+    DateTime? scheduledEndTime,
+    required int entityType,
+    String? entityId,
+    String? channelId,
+    String? location,
+  }) async {
+    final repo = ref.read(guildScheduledEventRepositoryProvider);
+    try {
+      final event = await repo.createGuildScheduledEvent(
+        guildId: guildId,
+        name: name,
+        description: description,
+        scheduledStartTime: scheduledStartTime,
+        scheduledEndTime: scheduledEndTime,
+        entityType: entityType,
+        entityId: entityId,
+        channelId: channelId,
+        location: location,
+      );
+      state = [...state, event];
+      return event;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  Future<void> deleteEvent(String eventId) async {
+    final repo = ref.read(guildScheduledEventRepositoryProvider);
+    try {
+      await repo.deleteGuildScheduledEvent(guildId: guildId, eventId: eventId);
+      state = state.where((e) => e.id != eventId).toList();
+    } catch (_) {}
+  }
+}
+
+@riverpod
+class EventSubscription extends _$EventSubscription {
+  @override
+  bool build({required String guildId, required String eventId}) {
+    _checkSubscription();
+    return false;
+  }
+
+  Future<void> _checkSubscription() async {
+    final repo = ref.read(guildScheduledEventRepositoryProvider);
+    try {
+      final subscribers = await repo.listEventSubscribers(
+        guildId: guildId,
+        eventId: eventId,
+      );
+      final authUserId = ref.read(fluxerAuthTokenProvider);
+      state = authUserId != null && subscribers.contains(authUserId);
+    } catch (_) {}
+  }
+
+  Future<void> toggle() async {
+    final repo = ref.read(guildScheduledEventRepositoryProvider);
+    try {
+      if (state) {
+        await repo.unsubscribeFromEvent(guildId: guildId, eventId: eventId);
+        state = false;
+      } else {
+        await repo.subscribeToEvent(guildId: guildId, eventId: eventId);
+        state = true;
+      }
+    } catch (_) {}
+  }
+}
+
+@riverpod
+class UserScheduledEvents extends _$UserScheduledEvents {
+  @override
+  List<GuildScheduledEvent> build() {
+    _fetchEvents();
+    return [];
+  }
+
+  Future<void> _fetchEvents() async {
+    final repo = ref.read(guildScheduledEventRepositoryProvider);
+    try {
+      final events = await repo.listUserScheduledEvents();
+      state = events;
+    } catch (_) {}
+  }
+
+  Future<void> refresh() async {
+    final repo = ref.read(guildScheduledEventRepositoryProvider);
+    try {
+      final events = await repo.listUserScheduledEvents();
+      state = events;
+    } catch (_) {}
+  }
+}


### PR DESCRIPTION
## Summary

This PR implements the Flutter mobile client for the guild scheduled events / calendar feature (bounty issue #3).

### Changes

**Flutter Client:**
- Created `GuildScheduledEvent` domain model with JSON serialization
- Created `GuildScheduledEventRepository` for API calls
- Created Riverpod providers for event state management
- Created `CalendarScreen` with month navigation and day selection
- Created `EventCard` widget for event display
- Created `CreateEventDialog` for event creation
- Created `EventDetailSheet` with subscription toggle
- Added `guild_calendar` route name and path

### Features
- **Calendar View**: Month navigation, day selection, event list
- **Event Creation**: Name, description, location, start/end times
- **Event Details**: Status, time, location, subscriber count, RSVP
- **Subscription**: Toggle "I'm Going" status

### User Stories Addressed
- Megan: View calendar, subscribe to events, see event details
- Hazel: Create events with full details
- View personal calendar with subscribed events