### PR TITLE
fix: friend nicknames everywhere

### DIFF
--- a/lib/core/database/daos/relationship_dao.dart
+++ b/lib/core/database/daos/relationship_dao.dart
@@ -14,8 +14,27 @@ class RelationshipDao extends DatabaseAccessor<FluxerDatabase>
 
   Future<List<Relationship>> getRelationships() => select(relationships).get();
 
+  Future<Map<String, String?>> getNicknamesByUserId() async {
+    final List<Relationship> rows = await select(relationships).get();
+    return <String, String?>{
+      for (final Relationship r in rows) r.userId: r.nickname,
+    };
+  }
+
   Stream<List<Relationship>> watchRelationships() =>
       select(relationships).watch();
+
+  Stream<Relationship?> watchRelationship(String userId) =>
+      (select(relationships)
+            ..where((r) => r.userId.equals(userId))
+            ..limit(1))
+          .watchSingleOrNull();
+
+  Future<Relationship?> getRelationship(String userId) =>
+      (select(relationships)
+            ..where((r) => r.userId.equals(userId))
+            ..limit(1))
+          .getSingleOrNull();
 
   Future<void> upsertRelationships(
     List<RelationshipsCompanion> relationshipList,

--- a/lib/features/chat/presentation/sheets/channel_details_sheet.dart
+++ b/lib/features/chat/presentation/sheets/channel_details_sheet.dart
@@ -39,6 +39,8 @@ import 'package:fluxer_app/features/dm/providers/dm_providers.dart';
 import 'package:fluxer_app/features/dm/providers/dm_view_model.dart';
 import 'package:fluxer_app/features/favorites/domain/favorite_guild_id.dart';
 import 'package:fluxer_app/features/favorites/providers/favorite_channels_provider.dart';
+import 'package:fluxer_app/features/friends/domain/friend.dart';
+import 'package:fluxer_app/features/friends/providers/friend_providers.dart';
 import 'package:fluxer_app/features/guilds/data/guild_user_settings_repository.dart';
 import 'package:fluxer_app/features/members/domain/group_dm_member_groups.dart';
 import 'package:fluxer_app/features/members/domain/member.dart';
@@ -287,12 +289,15 @@ class _ChannelDetailsSheetState extends ConsumerState<ChannelDetailsSheet> {
     if (dm == null) {
       return;
     }
+    final String? friendNickname = dm.isGroup
+        ? null
+        : ref.read(friendNicknameProvider(dm.recipientId)).value;
     await FluxerConfirmModal.show(
       context,
       title: dm.isGroup ? 'Leave Group' : 'Close DM',
       description: dm.isGroup
           ? 'Leave ${dm.displayName}?'
-          : 'Close your conversation with ${dm.displayName}?',
+          : 'Close your conversation with ${dm.displayNameWith(friendNickname)}?',
       confirmLabel: dm.isGroup ? 'Leave Group' : 'Close DM',
       isDanger: true,
       onConfirm: () {
@@ -570,7 +575,15 @@ class _DetailsIdentityHeader extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final Channel? channelEntity = channel;
-    final title = channelEntity?.name ?? dm?.displayName ?? 'Details';
+    final DmConversation? dmConvo = dm;
+    final String? friendNickname =
+        dmConvo != null && !dmConvo.isGroup && !dmConvo.isPersonalNotes
+        ? ref.watch(friendNicknameProvider(dmConvo.recipientId)).value
+        : null;
+    final title =
+        channelEntity?.name ??
+        dmConvo?.displayNameWith(friendNickname) ??
+        'Details';
     final subtitle = _detailsSubtitle(
       l10n: FluxerLocalizations.of(context),
       channel: channelEntity,
@@ -724,7 +737,9 @@ class _DetailsAvatar extends ConsumerWidget {
         );
       }
       return FluxerAvatar.user(
-        fallbackText: dm.recipientName,
+        fallbackText: dm.displayNameWith(
+          ref.watch(friendNicknameProvider(dm.recipientId)).value,
+        ),
         userId: dm.recipientId,
         imageUrl: FluxerMediaUrl.userAvatar(
           userId: dm.recipientId,
@@ -1514,10 +1529,14 @@ class _DmMemberGroups extends ConsumerWidget {
       return const SizedBox.shrink();
     }
     final db.User? currentUser = ref.watch(userPresenceProvider(userId)).value;
+    final Map<String, String?> friendNicknameById = friendNicknamesById(
+      ref.watch(friendsListProvider).value ?? const <Friend>[],
+    );
     final List<_DmParticipant> participants = _buildDmParticipants(
       dm: dm,
       currentUserId: userId,
       currentUser: currentUser,
+      friendNicknameById: friendNicknameById,
     );
     final Map<String, db.User?> presenceById = <String, db.User?>{
       for (final _DmParticipant participant in participants)
@@ -1574,9 +1593,15 @@ List<_DmParticipant> _buildDmParticipants({
   required DmConversation dm,
   required String currentUserId,
   required db.User? currentUser,
+  required Map<String, String?> friendNicknameById,
 }) {
   final List<_DmParticipant> participants = <_DmParticipant>[];
   final Set<String> addedIds = <String>{};
+
+  String withFriendNickname(String userId, String fallback) {
+    final String? nickname = friendNicknameById[userId]?.trim();
+    return nickname != null && nickname.isNotEmpty ? nickname : fallback;
+  }
 
   void add(_DmParticipant participant) {
     if (participant.id.isEmpty || !addedIds.add(participant.id)) {
@@ -1607,7 +1632,10 @@ List<_DmParticipant> _buildDmParticipants({
       add(
         _DmParticipant(
           id: member.id,
-          name: name.isEmpty ? member.id : member.name,
+          name: withFriendNickname(
+            member.id,
+            name.isEmpty ? member.id : member.name,
+          ),
           avatar: member.avatar,
         ),
       );
@@ -1618,7 +1646,10 @@ List<_DmParticipant> _buildDmParticipants({
   add(
     _DmParticipant(
       id: dm.recipientId,
-      name: dm.recipientName.trim().isEmpty ? dm.recipientId : dm.recipientName,
+      name: withFriendNickname(
+        dm.recipientId,
+        dm.recipientName.trim().isEmpty ? dm.recipientId : dm.recipientName,
+      ),
       avatar: dm.recipientAvatar,
       isBot: dm.isBot,
       isSystem: dm.isSystem,

--- a/lib/features/chat/presentation/sheets/message_reactions_sheet.dart
+++ b/lib/features/chat/presentation/sheets/message_reactions_sheet.dart
@@ -4,13 +4,18 @@ import 'package:cached_network_image_ce/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:fluxer_app/core/media/fluxer_media_url.dart';
+import 'package:fluxer_app/core/router/route_state_providers.dart';
 import 'package:fluxer_app/core/theme/fluxer_theme_extension.dart';
 import 'package:fluxer_app/features/chat/domain/message.dart';
 import 'package:fluxer_app/features/chat/providers/messages/message_reactors_provider.dart';
+import 'package:fluxer_app/features/friends/providers/friend_providers.dart';
 import 'package:fluxer_app/features/ui/avatar/fluxer_avatar.dart';
 import 'package:fluxer_app/features/ui/bottom_sheet/fluxer_bottom_sheet.dart';
 import 'package:fluxer_app/features/ui/spinner/fluxer_loading_spinner.dart';
 import 'package:fluxer_app/l10n/generated/fluxer_localizations.dart';
+import 'package:fluxer_app/shared/providers/guild_user_display_provider.dart';
+import 'package:fluxer_app/shared/utils/display_name.dart';
+import 'package:fluxer_app/shared/utils/guild_user_display.dart';
 import 'package:fluxer_app/shared/widgets/unicode_emoji_widget.dart';
 import 'package:fluxer_dart/export.dart';
 
@@ -281,15 +286,25 @@ class _ReactionTab extends StatelessWidget {
   }
 }
 
-class _ReactorRow extends StatelessWidget {
+class _ReactorRow extends ConsumerWidget {
   const _ReactorRow({required this.user});
 
   final UserPartialResponse user;
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final hasGlobalName = user.globalName?.isNotEmpty ?? false;
-    final displayName = hasGlobalName ? user.globalName! : user.username;
+    final String? guildId = ref.watch(activeGuildIdProvider);
+    final GuildUserDisplay? resolved = guildId == null || guildId.isEmpty
+        ? null
+        : ref.watch(guildUserDisplayFromDbProvider((user.id, guildId))).value;
+    final displayName =
+        resolved?.displayName ??
+        resolveDisplayName(
+          friendNickname: ref.watch(friendNicknameProvider(user.id)).value,
+          globalName: user.globalName,
+          username: user.username,
+        );
 
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 6),

--- a/lib/features/chat/presentation/widgets/channel/channel_header.dart
+++ b/lib/features/chat/presentation/widgets/channel/channel_header.dart
@@ -22,6 +22,7 @@ import 'package:fluxer_app/features/dm/providers/dm_view_model.dart';
 import 'package:fluxer_app/features/favorites/domain/favorite_guild_id.dart';
 import 'package:fluxer_app/features/favorites/providers/favorite_channels_provider.dart';
 import 'package:fluxer_app/features/favorites/utils/favorites_shell_navigation.dart';
+import 'package:fluxer_app/features/friends/providers/friend_providers.dart';
 import 'package:fluxer_app/features/gateway/providers/gateway_event_providers.dart';
 import 'package:fluxer_app/features/guilds/domain/guild.dart';
 import 'package:fluxer_app/features/guilds/providers/guild_list_view_model.dart';
@@ -659,11 +660,15 @@ class ChannelHeader extends ConsumerWidget {
     if (nickname != null && nickname.isNotEmpty) {
       return nickname;
     }
+    final String? friendNickname = dm != null && !dm.isGroup
+        ? ref.watch(friendNicknameProvider(dm.recipientId)).value
+        : null;
     return _resolveTitle(
       l10n: l10n,
       channel: channel,
       dm: dm,
       isPersonalNotes: isPersonalNotes,
+      friendNickname: friendNickname,
     );
   }
 
@@ -672,6 +677,7 @@ class ChannelHeader extends ConsumerWidget {
     required Channel? channel,
     required DmConversation? dm,
     required bool isPersonalNotes,
+    String? friendNickname,
   }) {
     if (channel != null) {
       return channel.name;
@@ -680,7 +686,7 @@ class ChannelHeader extends ConsumerWidget {
       return l10n.personalNotesTitle;
     }
     if (dm != null) {
-      return dm.displayName;
+      return dm.displayNameWith(friendNickname);
     }
     return '';
   }

--- a/lib/features/chat/presentation/widgets/composer/composer_autocomplete_field.dart
+++ b/lib/features/chat/presentation/widgets/composer/composer_autocomplete_field.dart
@@ -28,6 +28,7 @@ import 'package:fluxer_app/features/chat/utils/composer_mention_query.dart';
 import 'package:fluxer_app/features/chat/utils/emoji_autocomplete_search.dart';
 import 'package:fluxer_app/features/dm/domain/dm_conversation.dart';
 import 'package:fluxer_app/features/dm/providers/dm_view_model.dart';
+import 'package:fluxer_app/features/friends/domain/friend.dart';
 import 'package:fluxer_app/features/guilds/domain/guild.dart';
 import 'package:fluxer_app/features/guilds/providers/guild_list_view_model.dart';
 import 'package:fluxer_app/features/members/data/member_repository.dart';

--- a/lib/features/chat/presentation/widgets/composer/composer_autocomplete_field_state.dart
+++ b/lib/features/chat/presentation/widgets/composer/composer_autocomplete_field_state.dart
@@ -254,12 +254,16 @@ class ComposerAutocompleteFieldState
     if (generation != _syncGeneration) {
       return;
     }
+    final Map<String, String?> friendNicknameById = friendNicknamesById(
+      ref.read(dmViewModelProvider).friendsList,
+    );
     List<Member> ranked = rankMembersForMentionQuery(
       source.members,
       parsed,
       limit: _kMentionLimit,
       discriminatorByUserId: discs,
       prioritizeMemberIds: source.remoteSearchMemberIds,
+      friendNicknameById: friendNicknameById,
     );
     final Channel? ch = _guildChannel();
     final String? guildId = ch?.guildId;
@@ -280,7 +284,10 @@ class ComposerAutocompleteFieldState
     final List<_ComposerRow> rows = ranked
         .map(
           (Member m) => _ComposerRow(
-            title: memberDisplayLabel(m),
+            title: memberDisplayLabel(
+              m,
+              friendNickname: friendNicknameById[m.id],
+            ),
             subtitle: _composerMentionAutocompleteRightLabel(m, discs),
             onApply: () => _applyUserMention(trigger, m),
             mentionMember: m,
@@ -638,12 +645,22 @@ class ComposerAutocompleteFieldState
     final String userId = member.id;
     if (widget.controller is ComposerMentionController &&
         trigger.kind == ComposerAutocompleteTriggerKind.mention) {
+      String? friendNickname;
+      for (final friend in ref.read(dmViewModelProvider).friendsList) {
+        if (friend.id == userId) {
+          friendNickname = friend.nickname;
+          break;
+        }
+      }
       (widget.controller as ComposerMentionController)
           .insertUserMentionPlaceholder(
             matchStart: trigger.matchStart,
             matchEnd: trigger.matchEnd,
             userId: userId,
-            displayName: memberDisplayLabel(member),
+            displayName: memberDisplayLabel(
+              member,
+              friendNickname: friendNickname,
+            ),
           );
       _afterApply();
       return;
@@ -822,9 +839,7 @@ class ComposerAutocompleteFieldState
                   userAvatarImageUrl: m == null
                       ? null
                       : FluxerMediaUrl.userAvatar(userId: m.id, hash: m.avatar),
-                  userAvatarFallbackText: m != null
-                      ? memberDisplayLabel(m)
-                      : null,
+                  userAvatarFallbackText: m != null ? row.title : null,
                   userAvatarColor: m?.avatarColor,
                   userAvatarStatus: m == null
                       ? null

--- a/lib/features/chat/presentation/widgets/composer/typing_indicator_bar.dart
+++ b/lib/features/chat/presentation/widgets/composer/typing_indicator_bar.dart
@@ -7,6 +7,7 @@ import 'package:fluxer_app/features/chat/presentation/widgets/chat_loading_spinn
 import 'package:fluxer_app/features/chat/providers/core/chat_view_model.dart';
 import 'package:fluxer_app/features/chat/utils/chat_spinner_debug.dart';
 import 'package:fluxer_app/features/chat/utils/typing_indicator_text.dart';
+import 'package:fluxer_app/features/friends/providers/friend_providers.dart';
 import 'package:fluxer_app/features/profile/providers/user_presence_provider.dart';
 import 'package:fluxer_app/features/settings/providers/blocked_users_view_model.dart';
 import 'package:fluxer_app/features/ui/avatar/fluxer_avatar.dart';
@@ -65,6 +66,9 @@ class _TypingPill extends ConsumerWidget {
     required String? guildId,
   }) {
     final user = ref.watch(userPresenceProvider(userId)).value;
+    final String? friendNickname = ref
+        .watch(friendNicknameProvider(userId))
+        .value;
     if (guildId != null) {
       final GuildUserDisplay? guildDisplay = ref
           .watch(guildUserDisplayProvider((userId, guildId)))
@@ -77,6 +81,7 @@ class _TypingPill extends ConsumerWidget {
           user: user,
           member: null,
           guildId: guildId,
+          friendNickname: friendNickname,
         );
       }
       return fallbackTypingUserDisplay(userId);
@@ -92,6 +97,7 @@ class _TypingPill extends ConsumerWidget {
         user: user,
         member: null,
         guildId: null,
+        friendNickname: friendNickname,
       );
     }
     return fallbackTypingUserDisplay(userId);

--- a/lib/features/chat/presentation/widgets/messages/forwarded_message_content.dart
+++ b/lib/features/chat/presentation/widgets/messages/forwarded_message_content.dart
@@ -19,8 +19,10 @@ import 'package:fluxer_app/features/chat/presentation/widgets/messages/message_m
 import 'package:fluxer_app/features/chat/presentation/widgets/messages/spoiler_overlay.dart';
 import 'package:fluxer_app/features/chat/utils/channel_jump_navigator.dart';
 import 'package:fluxer_app/features/chat/utils/spoiler_utils.dart';
+import 'package:fluxer_app/features/dm/domain/dm_channel_types.dart';
 import 'package:fluxer_app/features/guilds/domain/guild.dart';
 import 'package:fluxer_app/features/settings/providers/chat_preferences_provider.dart';
+import 'package:fluxer_app/shared/utils/display_name.dart';
 import 'package:fluxer_app/shared/utils/guild_name_abbreviation.dart';
 import 'package:fluxer_markdown/fluxer_markdown.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
@@ -298,7 +300,7 @@ class _ForwardedSourceButtonState
       return null;
     }
 
-    if (dmChannel.type == 3) {
+    if (isDmGroupType(dmChannel.type)) {
       return _ForwardedSourceData.groupDm(
         channelId: widget.reference.channelId,
         messageId: widget.reference.messageId,
@@ -307,7 +309,14 @@ class _ForwardedSourceButtonState
     }
 
     final user = await db.userDao.getUserById(dmChannel.recipientId);
-    final name = user?.globalName ?? user?.username ?? dmChannel.recipientId;
+    final relationship = await db.relationshipDao.getRelationship(
+      dmChannel.recipientId,
+    );
+    final name = resolveDisplayName(
+      friendNickname: relationship?.nickname,
+      globalName: user?.globalName,
+      username: user?.username ?? dmChannel.recipientId,
+    );
     return _ForwardedSourceData.dm(
       channelId: widget.reference.channelId,
       messageId: widget.reference.messageId,

--- a/lib/features/chat/presentation/widgets/messages/message_mention.dart
+++ b/lib/features/chat/presentation/widgets/messages/message_mention.dart
@@ -13,11 +13,13 @@ import 'package:fluxer_app/features/channels/domain/channel.dart';
 import 'package:fluxer_app/features/channels/presentation/widgets/channel_icon.dart';
 import 'package:fluxer_app/features/channels/providers/channel_providers.dart';
 import 'package:fluxer_app/features/chat/utils/channel_jump_navigator.dart';
+import 'package:fluxer_app/features/dm/domain/dm_channel_types.dart';
 import 'package:fluxer_app/features/guilds/domain/guild.dart';
 import 'package:fluxer_app/features/guilds/providers/role_providers.dart';
 import 'package:fluxer_app/features/profile/presentation/user_profile_sheet.dart';
 import 'package:fluxer_app/l10n/generated/fluxer_localizations.dart';
 import 'package:fluxer_app/shared/providers/guild_user_display_provider.dart';
+import 'package:fluxer_app/shared/utils/display_name.dart';
 import 'package:fluxer_app/shared/utils/guild_name_abbreviation.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
 
@@ -228,11 +230,21 @@ final FutureProviderFamily<String?, String> _dmNameByChannelIdProvider =
       if (row == null) {
         return null;
       }
-      final user = await db.userDao.getUserById(row.recipientId);
-      if (row.type == 3) {
+      if (isDmGroupType(row.type)) {
         return row.name ?? 'Group DM';
       }
-      return user?.globalName ?? user?.username;
+      final user = await db.userDao.getUserById(row.recipientId);
+      if (user == null) {
+        return null;
+      }
+      final relationship = await db.relationshipDao.getRelationship(
+        row.recipientId,
+      );
+      return resolveDisplayName(
+        friendNickname: relationship?.nickname,
+        globalName: user.globalName,
+        username: user.username,
+      );
     });
 
 class ChannelJumpLinkMention extends ConsumerWidget {

--- a/lib/features/chat/presentation/widgets/messages/system_message.dart
+++ b/lib/features/chat/presentation/widgets/messages/system_message.dart
@@ -1,10 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:fluxer_app/core/router/fluxer_router.dart';
 import 'package:fluxer_app/core/theme/fluxer_theme_extension.dart';
 import 'package:fluxer_app/features/chat/domain/message.dart';
 import 'package:fluxer_app/features/chat/utils/message_timestamp_format.dart';
 import 'package:fluxer_app/features/chat/utils/system_message_text.dart';
 import 'package:fluxer_app/l10n/generated/fluxer_localizations.dart';
+import 'package:fluxer_app/shared/providers/guild_user_display_provider.dart';
 import 'package:fluxer_app/shared/providers/member_role_color.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
 
@@ -28,6 +30,12 @@ class SystemMessage extends ConsumerWidget {
                 memberRoleColorProvider((message.authorId, resolvedGuildId)),
               )
               .value;
+    final String authorName = watchMessageAuthorDisplay(
+      ref: ref,
+      message: message,
+      guildId: resolvedGuildId,
+      currentUserId: ref.watch(currentUserIdProvider),
+    ).displayName;
     final textStyle = TextStyle(
       color: context.colors.textTertiaryMuted,
       fontSize: 14,
@@ -39,6 +47,7 @@ class SystemMessage extends ConsumerWidget {
     );
     final (icon, textSpans) = _iconAndTextSpans(
       context,
+      authorName: authorName,
       textStyle: textStyle,
       usernameStyle: usernameStyle,
     );
@@ -83,6 +92,7 @@ class SystemMessage extends ConsumerWidget {
 
   (IconData, List<InlineSpan>) _iconAndTextSpans(
     BuildContext context, {
+    required String authorName,
     required TextStyle textStyle,
     required TextStyle usernameStyle,
   }) {
@@ -91,6 +101,7 @@ class SystemMessage extends ConsumerWidget {
         PhosphorIconsBold.arrowRight,
         _guildJoinTextSpans(
           FluxerLocalizations.of(context),
+          authorName: authorName,
           textStyle: textStyle,
           usernameStyle: usernameStyle,
         ),
@@ -101,7 +112,7 @@ class SystemMessage extends ConsumerWidget {
     return (
       icon,
       <InlineSpan>[
-        TextSpan(text: message.authorName, style: usernameStyle),
+        TextSpan(text: authorName, style: usernameStyle),
         TextSpan(text: ' $text', style: textStyle),
       ],
     );
@@ -109,6 +120,7 @@ class SystemMessage extends ConsumerWidget {
 
   List<InlineSpan> _guildJoinTextSpans(
     FluxerLocalizations l10n, {
+    required String authorName,
     required TextStyle textStyle,
     required TextStyle usernameStyle,
   }) {
@@ -124,7 +136,7 @@ class SystemMessage extends ConsumerWidget {
       for (var i = 0; i < parts.length; i++) ...[
         if (parts[i].isNotEmpty) TextSpan(text: parts[i], style: textStyle),
         if (i < parts.length - 1)
-          TextSpan(text: message.authorName, style: usernameStyle),
+          TextSpan(text: authorName, style: usernameStyle),
       ],
     ];
   }

--- a/lib/features/chat/utils/composer_mention_query.dart
+++ b/lib/features/chat/utils/composer_mention_query.dart
@@ -1,4 +1,5 @@
 import 'package:fluxer_app/features/members/domain/member.dart';
+import 'package:fluxer_app/shared/utils/display_name.dart';
 
 class ParsedMentionQuery {
   const ParsedMentionQuery({
@@ -28,26 +29,35 @@ ParsedMentionQuery parseMentionQuery(String query) {
   );
 }
 
-String memberDisplayLabel(Member member) => member.displayName;
+String memberDisplayLabel(Member member, {String? friendNickname}) =>
+    resolveDisplayName(
+      guildNickname: member.nickname,
+      friendNickname: friendNickname,
+      globalName: member.globalName,
+      username: member.username,
+    );
 
 bool memberMatchesMentionQuery(
   Member member,
   ParsedMentionQuery parsed,
-  String? discriminator,
-) {
+  String? discriminator, {
+  String? friendNickname,
+}) {
   final String trimmedUsername = parsed.usernameQuery.trim();
   final String disc = discriminator ?? '0';
   if (parsed.hasTagSeparator) {
     final String uq = parsed.usernameQuery.toLowerCase();
     final String tq = (parsed.tagQuery ?? '').toLowerCase();
     final String nick = (member.nickname ?? '').toLowerCase();
+    final String fn = (friendNickname ?? '').toLowerCase();
     final String un = member.username.toLowerCase();
     final String gn = (member.globalName ?? '').toLowerCase();
     final bool matchesUsername =
         uq.isEmpty ||
         un.startsWith(uq) ||
         gn.startsWith(uq) ||
-        nick.startsWith(uq);
+        nick.startsWith(uq) ||
+        fn.startsWith(uq);
     final bool matchesTag = tq.isEmpty || disc.toLowerCase().startsWith(tq);
     return matchesUsername && matchesTag;
   }
@@ -56,14 +66,23 @@ bool memberMatchesMentionQuery(
   }
   final String q = trimmedUsername.toLowerCase();
   final String haystack =
-      '${memberDisplayLabel(member)} ${member.username} ${member.globalName ?? ''}'
+      '${memberDisplayLabel(member, friendNickname: friendNickname)} ${member.username} ${member.globalName ?? ''}'
           .toLowerCase();
   return haystack.contains(q);
 }
 
-int _memberSortKey(Member a, Member b) => memberDisplayLabel(
-  a,
-).toLowerCase().compareTo(memberDisplayLabel(b).toLowerCase());
+int _memberSortKey(
+  Member a,
+  Member b,
+  Map<String, String?> friendNicknameById,
+) => memberDisplayLabel(a, friendNickname: friendNicknameById[a.id])
+    .toLowerCase()
+    .compareTo(
+      memberDisplayLabel(
+        b,
+        friendNickname: friendNicknameById[b.id],
+      ).toLowerCase(),
+    );
 
 List<Member> rankMembersForMentionQuery(
   List<Member> members,
@@ -71,16 +90,23 @@ List<Member> rankMembersForMentionQuery(
   required int limit,
   Map<String, String>? discriminatorByUserId,
   Set<String>? prioritizeMemberIds,
+  Map<String, String?> friendNicknameById = const <String, String?>{},
 }) {
   final List<Member> filtered = members
       .where(
-        (Member m) =>
-            memberMatchesMentionQuery(m, parsed, discriminatorByUserId?[m.id]),
+        (Member m) => memberMatchesMentionQuery(
+          m,
+          parsed,
+          discriminatorByUserId?[m.id],
+          friendNickname: friendNicknameById[m.id],
+        ),
       )
       .toList();
   final Set<String> prefer = prioritizeMemberIds ?? const <String>{};
   if (prefer.isEmpty) {
-    filtered.sort(_memberSortKey);
+    filtered.sort(
+      (Member a, Member b) => _memberSortKey(a, b, friendNicknameById),
+    );
   } else {
     int compare(Member a, Member b) {
       final bool pa = prefer.contains(a.id);
@@ -88,7 +114,7 @@ List<Member> rankMembersForMentionQuery(
       if (pa != pb) {
         return pa ? -1 : 1;
       }
-      return _memberSortKey(a, b);
+      return _memberSortKey(a, b, friendNicknameById);
     }
 
     filtered.sort(compare);

--- a/lib/features/dm/domain/dm_channel_types.dart
+++ b/lib/features/dm/domain/dm_channel_types.dart
@@ -6,6 +6,8 @@ import 'package:fluxer_app/features/dm/domain/dm_conversation.dart';
 import 'package:fluxer_app/shared/utils/snowflake_time.dart';
 import 'package:fluxer_dart/export.dart';
 
+const int dmGroupChannelType = 3;
+
 const int dmPersonalNotesChannelType = 999;
 
 const String fluxerBotUserId = '0';
@@ -31,6 +33,8 @@ bool canCallUser({required bool isBot, required bool isSystem}) =>
     !isBot && !isSystem;
 
 bool shouldShowDmRecipientPresence(DmConversation dm) => !dm.isSystem;
+
+bool isDmGroupType(int type) => type == dmGroupChannelType;
 
 bool isDmPersonalNotesType(int type) => type == dmPersonalNotesChannelType;
 

--- a/lib/features/dm/domain/dm_conversation.dart
+++ b/lib/features/dm/domain/dm_conversation.dart
@@ -1,5 +1,6 @@
 import 'package:fluxer_app/core/database/fluxer_database.dart' as db;
 import 'package:fluxer_app/features/dm/domain/dm_channel_types.dart';
+import 'package:fluxer_app/shared/utils/display_name.dart';
 
 class GroupMemberInfo {
   final String id;
@@ -59,7 +60,7 @@ class DmConversation {
     this.remoteRecipientIds = const [],
   });
 
-  bool get isGroup => type == 3;
+  bool get isGroup => isDmGroupType(type);
 
   bool get isPersonalNotes => isDmPersonalNotesType(type);
 
@@ -71,6 +72,16 @@ class DmConversation {
       return name ?? 'Group DM';
     }
     return recipientName;
+  }
+
+  String displayNameWith(String? friendNickname) {
+    if (isGroup || isPersonalNotes) {
+      return displayName;
+    }
+    return resolveDisplayName(
+      friendNickname: friendNickname,
+      username: displayName,
+    );
   }
 
   String? get recipientTag {

--- a/lib/features/dm/presentation/widgets/dm_list.dart
+++ b/lib/features/dm/presentation/widgets/dm_list.dart
@@ -27,6 +27,7 @@ import 'package:fluxer_app/features/dm/providers/dm_providers.dart';
 import 'package:fluxer_app/features/dm/providers/dm_view_model.dart';
 import 'package:fluxer_app/features/favorites/domain/favorite_guild_id.dart';
 import 'package:fluxer_app/features/favorites/providers/favorite_channels_provider.dart';
+import 'package:fluxer_app/features/friends/presentation/change_friend_nickname.dart';
 import 'package:fluxer_app/features/friends/providers/friend_providers.dart';
 import 'package:fluxer_app/features/guilds/providers/guild_list_view_model.dart';
 import 'package:fluxer_app/features/members/domain/group_dm_member_groups.dart';
@@ -676,6 +677,9 @@ class _DMListState extends ConsumerState<DMList> {
     final layout = context.layout;
     final hasUnread = c.unreadCount > 0;
     final currentUserId = ref.watch(currentUserIdProvider);
+    final String displayName = c.displayNameWith(
+      c.isGroup ? null : ref.watch(friendNicknameProvider(c.recipientId)).value,
+    );
     final titleColor = isSelected
         ? context.colors.surfaceInteractiveSelectedColor
         : hasUnread
@@ -690,9 +694,14 @@ class _DMListState extends ConsumerState<DMList> {
 
     String lastMessagePreview = c.lastMessage;
     if (c.lastMessage.isNotEmpty && c.lastMessageAuthorName != null) {
-      final prefix = c.lastMessageAuthorId == currentUserId
+      final String? authorId = c.lastMessageAuthorId;
+      final String? authorFriendNickname =
+          authorId != null && authorId.isNotEmpty
+          ? ref.watch(friendNicknameProvider(authorId)).value
+          : null;
+      final prefix = authorId == currentUserId
           ? 'You'
-          : c.lastMessageAuthorName!;
+          : (authorFriendNickname ?? c.lastMessageAuthorName!);
       lastMessagePreview = '$prefix: ${c.lastMessage}';
     }
 
@@ -747,7 +756,7 @@ class _DMListState extends ConsumerState<DMList> {
                           )
                         : null;
                     return FluxerAvatar.user(
-                      fallbackText: c.recipientName,
+                      fallbackText: displayName,
                       userId: c.recipientId,
                       imageUrl: FluxerMediaUrl.userAvatar(
                         userId: c.recipientId,
@@ -779,7 +788,7 @@ class _DMListState extends ConsumerState<DMList> {
                             ),
                           Flexible(
                             child: Text(
-                              c.displayName,
+                              displayName,
                               style: context.textStyles.username.copyWith(
                                 color: titleColor,
                               ),
@@ -929,8 +938,15 @@ class _DMListState extends ConsumerState<DMList> {
         // TODO(Elias): open add note sheet
         break;
       case _DmAction.changeFriendNickname:
-        // TODO(M0n7y5): open change friend nickname sheet
-        break;
+        unawaited(
+          showChangeFriendNicknameSheet(
+            context,
+            ref,
+            userId: convo.recipientId,
+            username: convo.recipientUsername ?? convo.recipientName,
+            currentNick: rel?.nickname,
+          ),
+        );
       case _DmAction.favoriteDm:
         final repository = ref.read(favoriteChannelsRepositoryProvider);
         if (await repository.isFavorite(convo.id)) {
@@ -1009,7 +1025,9 @@ class _DMListState extends ConsumerState<DMList> {
         await FluxerConfirmModal.show(
           context,
           title: l10n.dmRemoveFriendConfirmTitle,
-          description: l10n.dmRemoveFriendConfirmDescription(convo.displayName),
+          description: l10n.dmRemoveFriendConfirmDescription(
+            convo.displayNameWith(rel?.nickname),
+          ),
           confirmLabel: l10n.dmRemoveFriend,
           isDanger: true,
           onConfirm: () {
@@ -1108,7 +1126,9 @@ class _DMListState extends ConsumerState<DMList> {
         await FluxerConfirmModal.show(
           context,
           title: l10n.dmBlockConfirmTitle,
-          description: l10n.dmBlockConfirmDescription(convo.displayName),
+          description: l10n.dmBlockConfirmDescription(
+            convo.displayNameWith(rel?.nickname),
+          ),
           confirmLabel: l10n.dmBlock,
           isDanger: true,
           onConfirm: () {
@@ -1158,7 +1178,9 @@ class _DMListState extends ConsumerState<DMList> {
         final confirmed = await FluxerConfirmModal.show(
           context,
           title: l10n.dmCloseDmConfirmTitle,
-          description: l10n.dmCloseDmConfirmDescription(convo.displayName),
+          description: l10n.dmCloseDmConfirmDescription(
+            convo.displayNameWith(rel?.nickname),
+          ),
           confirmLabel: l10n.dmCloseDm,
           isDanger: true,
           onConfirm: () {
@@ -1414,6 +1436,11 @@ class _DmBottomSheet extends ConsumerWidget {
     final layout = context.layout;
     final l10n = FluxerLocalizations.of(context);
     final hasUnread = convo.unreadCount > 0;
+    final String displayName = convo.displayNameWith(
+      convo.isGroup
+          ? null
+          : ref.watch(friendNicknameProvider(convo.recipientId)).value,
+    );
 
     void pop(Object action) => Navigator.of(context).pop(action);
 
@@ -1660,7 +1687,7 @@ class _DmBottomSheet extends ConsumerWidget {
                         ),
                       )
                     : FluxerAvatar.user(
-                        fallbackText: convo.recipientName,
+                        fallbackText: displayName,
                         userId: convo.recipientId,
                         imageUrl: FluxerMediaUrl.userAvatar(
                           userId: convo.recipientId,
@@ -1672,7 +1699,7 @@ class _DmBottomSheet extends ConsumerWidget {
                         showStatus: shouldShowDmRecipientPresence(convo),
                         size: 48,
                       ),
-                title: convo.displayName,
+                title: displayName,
                 subtitle: convo.isGroup
                     ? Text(
                         l10n.dmGroupMemberCount(convo.memberCount),

--- a/lib/features/dm/presentation/widgets/dm_navbar_item.dart
+++ b/lib/features/dm/presentation/widgets/dm_navbar_item.dart
@@ -12,6 +12,7 @@ import 'package:fluxer_app/features/dm/presentation/widgets/group_dm_avatar.dart
 import 'package:fluxer_app/features/dm/providers/dm_mute_provider.dart';
 import 'package:fluxer_app/features/dm/providers/dm_view_model.dart';
 import 'package:fluxer_app/features/dm/providers/unread_dm_provider.dart';
+import 'package:fluxer_app/features/friends/providers/friend_providers.dart';
 import 'package:fluxer_app/features/profile/providers/user_presence_provider.dart';
 import 'package:fluxer_app/features/settings/providers/user_settings_view_model.dart';
 import 'package:fluxer_app/features/ui/ui.dart';
@@ -97,6 +98,10 @@ class _DmNavbarItemState extends ConsumerState<DmNavbarItem>
     final recipient = isGroup
         ? null
         : ref.watch(userPresenceProvider(widget.recipientId)).value;
+    final String displayName = isGroup
+        ? widget.displayName
+        : ref.watch(friendNicknameProvider(widget.recipientId)).value ??
+              widget.displayName;
     final avatarImageUrl = isGroup
         ? null
         : FluxerMediaUrl.userAvatar(
@@ -153,7 +158,7 @@ class _DmNavbarItemState extends ConsumerState<DmNavbarItem>
                   ),
                   const SizedBox(width: 6),
                   FluxerTooltip(
-                    message: widget.displayName,
+                    message: displayName,
                     position: FluxerTooltipPosition.right,
                     child: SizedBox(
                       width: 48,
@@ -185,7 +190,7 @@ class _DmNavbarItemState extends ConsumerState<DmNavbarItem>
                                             size: 44,
                                           )
                                   : FluxerAvatar.user(
-                                      fallbackText: widget.displayName,
+                                      fallbackText: displayName,
                                       userId: widget.recipientId,
                                       imageUrl: avatarImageUrl,
                                       avatarColor: avatarColor,

--- a/lib/features/friends/data/friend_repository.dart
+++ b/lib/features/friends/data/friend_repository.dart
@@ -14,12 +14,15 @@ class FriendRepository {
 
   Stream<List<Friend>> watchRelationships() {
     return _db.relationshipDao.watchRelationships().asyncMap((rows) async {
-      final result = <Friend>[];
-      for (final row in rows) {
-        final user = await _db.userDao.getUserById(row.userId);
-        result.add(Friend.fromRow(row, user));
-      }
-      return result;
+      final List<db.User> users = await _db.userDao.getUsersByIds(
+        rows.map((row) => row.userId).toList(),
+      );
+      final Map<String, db.User> usersById = <String, db.User>{
+        for (final db.User user in users) user.id: user,
+      };
+      return rows
+          .map((row) => Friend.fromRow(row, usersById[row.userId]))
+          .toList();
     });
   }
 
@@ -85,6 +88,22 @@ class FriendRepository {
       throw Exception(
         e.response?.statusMessage ?? 'Failed to accept friend request',
       );
+    }
+  }
+
+  Future<void> updateNickname({
+    required String userId,
+    required String? nickname,
+  }) async {
+    try {
+      final RelationshipResponse relationship = await _client.users
+          .updateRelationshipNickname(
+            userId: userId,
+            body: RelationshipNicknameUpdateRequest(nickname: nickname),
+          );
+      await _upsertRelationship(relationship);
+    } on DioException catch (e) {
+      throw Exception(e.response?.statusMessage ?? 'Failed to update nickname');
     }
   }
 

--- a/lib/features/friends/domain/friend.dart
+++ b/lib/features/friends/domain/friend.dart
@@ -1,7 +1,13 @@
 import 'package:fluxer_app/core/database/fluxer_database.dart' as db;
+import 'package:fluxer_app/shared/utils/display_name.dart';
 import 'package:fluxer_dart/export.dart';
 
 enum FriendStatus { accepted, pendingIncoming, pendingOutgoing, blocked }
+
+Map<String, String?> friendNicknamesById(Iterable<Friend> friends) =>
+    <String, String?>{
+      for (final Friend friend in friends) friend.id: friend.nickname,
+    };
 
 class Friend {
   final String id;
@@ -60,7 +66,12 @@ class Friend {
     );
   }
 
-  String get displayName => globalName ?? username;
+  String get displayName => resolveDisplayName(
+    friendNickname: nickname,
+    globalName: globalName,
+    username: username,
+  );
+
   String get tag => '$username#$discriminator';
 
   static FriendStatus _mapType(RelationshipTypes type) => switch (type) {

--- a/lib/features/friends/presentation/change_friend_nickname.dart
+++ b/lib/features/friends/presentation/change_friend_nickname.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:fluxer_app/features/friends/providers/friend_providers.dart';
+import 'package:fluxer_app/features/profile/presentation/sheets/change_nickname_sheet.dart';
+import 'package:fluxer_app/features/ui/ui.dart';
+import 'package:fluxer_app/l10n/generated/fluxer_localizations.dart';
+
+Future<void> showChangeFriendNicknameSheet(
+  BuildContext context,
+  WidgetRef ref, {
+  required String userId,
+  required String username,
+  required String? currentNick,
+}) async {
+  final ChangeNicknameResult? result = await ChangeNicknameSheet.show(
+    context,
+    username: username,
+    currentNick: currentNick,
+  );
+  if (result == null || !context.mounted) {
+    return;
+  }
+  final FluxerLocalizations l10n = FluxerLocalizations.of(context);
+  final toast = ref.read(toastProvider.notifier);
+  try {
+    await ref
+        .read(friendRepositoryProvider)
+        .updateNickname(userId: userId, nickname: result.nick);
+    toast.show(
+      FluxerToast(
+        message: l10n.userProfileNicknameSuccess,
+        variant: FluxerToastVariant.success,
+      ),
+    );
+  } on Object {
+    toast.show(
+      FluxerToast(
+        message: l10n.userProfileActionFailed,
+        variant: FluxerToastVariant.danger,
+      ),
+    );
+  }
+}

--- a/lib/features/friends/providers/friend_providers.dart
+++ b/lib/features/friends/providers/friend_providers.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/misc.dart';
 import 'package:fluxer_app/core/api/fluxer_client_provider.dart';
 import 'package:fluxer_app/core/providers/database_provider.dart';
 import 'package:fluxer_app/features/friends/data/friend_repository.dart';
@@ -18,6 +19,15 @@ FriendRepository friendRepository(Ref ref) {
 final friendsListProvider = StreamProvider<List<Friend>>((ref) {
   return ref.watch(friendRepositoryProvider).watchRelationships();
 });
+
+final StreamProviderFamily<String?, String> friendNicknameProvider =
+    StreamProvider.autoDispose.family<String?, String>((ref, userId) {
+      final db = ref.watch(fluxerDatabaseProvider);
+      return db.relationshipDao.watchRelationship(userId).map((row) {
+        final String? nick = row?.nickname?.trim();
+        return nick == null || nick.isEmpty ? null : nick;
+      });
+    });
 
 /// Pending incoming friend request count (type 3 = pendingIncoming).
 final pendingFriendRequestCountProvider = StreamProvider<int>((ref) {

--- a/lib/features/guilds/presentation/widgets/guild_navbar.dart
+++ b/lib/features/guilds/presentation/widgets/guild_navbar.dart
@@ -25,6 +25,7 @@ import 'package:fluxer_app/core/theme/fluxer_theme_extension.dart';
 import 'package:fluxer_app/features/channels/domain/channel.dart';
 import 'package:fluxer_app/features/channels/presentation/widgets/channel_icon.dart';
 import 'package:fluxer_app/features/channels/providers/channel_providers.dart';
+import 'package:fluxer_app/features/dm/domain/dm_channel_types.dart';
 import 'package:fluxer_app/features/dm/domain/dm_conversation.dart';
 import 'package:fluxer_app/features/dm/presentation/widgets/dm_navbar_context_menu.dart';
 import 'package:fluxer_app/features/dm/presentation/widgets/dm_navbar_item.dart';
@@ -67,6 +68,7 @@ import 'package:fluxer_app/features/ui/ui.dart';
 import 'package:fluxer_app/features/ui/warning_alert/fluxer_warning_alert.dart';
 import 'package:fluxer_app/l10n/generated/fluxer_localizations.dart';
 import 'package:fluxer_app/shared/external_links/external_link_handler.dart';
+import 'package:fluxer_app/shared/utils/display_name.dart';
 import 'package:fluxer_app/shared/utils/guild_name_abbreviation.dart';
 import 'package:fluxer_app/shared/widgets/debug_bottom_sheet.dart';
 import 'package:fluxer_dart/export.dart';
@@ -720,7 +722,14 @@ class _GuildNavbarState extends ConsumerState<GuildNavbar> {
     final l10n = FluxerLocalizations.of(context);
     final db = ref.read(fluxerDatabaseProvider);
     final user = await db.userDao.getUserById(dm.recipientId);
-    final username = user?.globalName ?? user?.username ?? dm.recipientId;
+    final relationship = isDmGroupType(dm.type)
+        ? null
+        : await db.relationshipDao.getRelationship(dm.recipientId);
+    final username = resolveDisplayName(
+      friendNickname: relationship?.nickname,
+      globalName: user?.globalName,
+      username: user?.username ?? dm.recipientId,
+    );
 
     if (!context.mounted) {
       return;

--- a/lib/features/members/domain/member.dart
+++ b/lib/features/members/domain/member.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 
 import 'package:fluxer_app/core/database/fluxer_database.dart' as db;
+import 'package:fluxer_app/shared/utils/display_name.dart';
 import 'package:fluxer_app/shared/utils/guild_user_display.dart';
 
 class MemberRole {
@@ -107,7 +108,11 @@ class Member {
     );
   }
 
-  String get displayName => nickname ?? globalName ?? username;
+  String get displayName => resolveDisplayName(
+    guildNickname: nickname,
+    globalName: globalName,
+    username: username,
+  );
 
   /// Whether the member is currently timed out (communication disabled).
   bool get isTimedOut =>

--- a/lib/features/members/presentation/widgets/member_list_member_row.dart
+++ b/lib/features/members/presentation/widgets/member_list_member_row.dart
@@ -6,6 +6,7 @@ import 'package:fluxer_app/core/database/fluxer_database.dart' as db;
 import 'package:fluxer_app/core/media/fluxer_media_url.dart';
 import 'package:fluxer_app/core/theme/fluxer_layout_theme.dart';
 import 'package:fluxer_app/core/theme/fluxer_theme_extension.dart';
+import 'package:fluxer_app/features/friends/providers/friend_providers.dart';
 import 'package:fluxer_app/features/members/domain/group_dm_member_groups.dart';
 import 'package:fluxer_app/features/members/domain/member_list_group_names.dart';
 import 'package:fluxer_app/features/members/presentation/widgets/member_list_shared_widgets.dart';
@@ -13,10 +14,22 @@ import 'package:fluxer_app/features/profile/domain/custom_status_utils.dart';
 import 'package:fluxer_app/features/profile/presentation/user_profile_sheet.dart';
 import 'package:fluxer_app/features/profile/providers/user_presence_provider.dart';
 import 'package:fluxer_app/features/ui/ui.dart';
+import 'package:fluxer_app/shared/utils/display_name.dart';
 import 'package:fluxer_app/shared/widgets/custom_status_display.dart';
 import 'package:fluxer_dart/export.dart';
 import 'package:fluxer_dart/gateway.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
+
+String _memberDisplayName(
+  WidgetRef ref,
+  GuildMemberResponse member,
+  String userId,
+) => resolveDisplayName(
+  guildNickname: member.nick,
+  friendNickname: ref.watch(friendNicknameProvider(userId)).value,
+  globalName: member.user.globalName,
+  username: member.user.username,
+);
 
 class MemberListSidebarMemberRow extends ConsumerStatefulWidget {
   const MemberListSidebarMemberRow({
@@ -45,8 +58,7 @@ class _MemberListSidebarMemberRowState
   Widget build(BuildContext context) {
     final MemberListMember listMember = widget.listMember;
     final GuildMemberResponse member = listMember.member;
-    final String displayName =
-        member.nick ?? member.user.globalName ?? member.user.username;
+    final String displayName = _memberDisplayName(ref, member, widget.userId);
     final String? avatar = member.avatar ?? member.user.avatar;
     final db.User? presenceUser = ref
         .watch(userPresenceProvider(widget.userId))
@@ -174,8 +186,7 @@ class MemberListDetailsMemberRow extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final GuildMemberResponse member = listMember.member;
-    final String displayName =
-        member.nick ?? member.user.globalName ?? member.user.username;
+    final String displayName = _memberDisplayName(ref, member, userId);
     final String? avatar = member.avatar ?? member.user.avatar;
     final db.User? presenceUser = ref.watch(userPresenceProvider(userId)).value;
     final String status =

--- a/lib/features/notifications/data/mention_header_loader.dart
+++ b/lib/features/notifications/data/mention_header_loader.dart
@@ -1,8 +1,10 @@
 import 'package:fluxer_app/core/database/fluxer_database.dart' as drift_db;
 import 'package:fluxer_app/features/channels/domain/channel.dart' as domain;
 import 'package:fluxer_app/features/chat/domain/message.dart';
+import 'package:fluxer_app/features/dm/domain/dm_channel_types.dart';
 import 'package:fluxer_app/features/guilds/domain/guild.dart';
 import 'package:fluxer_app/features/notifications/domain/mention_header.dart';
+import 'package:fluxer_app/shared/utils/display_name.dart';
 
 const String _kFallbackDmTitle = 'DM';
 
@@ -128,7 +130,17 @@ Future<MentionHeaderResult> _buildDmHeader(
   String title = dm.name?.trim() ?? '';
   if (title.isEmpty && dm.recipientId.isNotEmpty) {
     final drift_db.User? user = await db.userDao.getUserById(dm.recipientId);
-    title = user?.username ?? _kFallbackDmTitle;
+    final drift_db.Relationship? relationship = await db.relationshipDao
+        .getRelationship(dm.recipientId);
+    title = user == null
+        ? _kFallbackDmTitle
+        : resolveDisplayName(
+            friendNickname: isDmGroupType(dm.type)
+                ? null
+                : relationship?.nickname,
+            globalName: user.globalName,
+            username: user.username,
+          );
   }
   if (title.isEmpty) {
     title = _kFallbackDmTitle;

--- a/lib/features/profile/presentation/sheets/user_profile_actions_sheet.dart
+++ b/lib/features/profile/presentation/sheets/user_profile_actions_sheet.dart
@@ -5,6 +5,7 @@ import 'package:fluxer_app/core/api/fluxer_client_provider.dart';
 import 'package:fluxer_app/core/talker.dart';
 import 'package:fluxer_app/features/chat/domain/message.dart';
 import 'package:fluxer_app/features/friends/domain/friend.dart';
+import 'package:fluxer_app/features/friends/presentation/change_friend_nickname.dart';
 import 'package:fluxer_app/features/friends/providers/friend_providers.dart';
 import 'package:fluxer_app/features/moderation/iar/iar_flow.dart';
 import 'package:fluxer_app/features/moderation/iar/iar_simple_report_sheet.dart';
@@ -341,6 +342,20 @@ class UserProfileActionsSheet {
         if (!isCurrentUser) {
           if (status == FriendStatus.accepted) {
             groups.add(<Widget>[
+              FluxerMenuItem(
+                label: l10n.dmChangeFriendNickname,
+                icon: PhosphorIconsFill.pencilSimple,
+                onPressed: () async {
+                  close();
+                  await showChangeFriendNicknameSheet(
+                    context,
+                    ref,
+                    userId: user.id,
+                    username: user.username,
+                    currentNick: relationship?.nickname,
+                  );
+                },
+              ),
               FluxerMenuItem(
                 label: l10n.userProfileRemoveFriend,
                 icon: PhosphorIconsFill.userMinus,

--- a/lib/features/profile/presentation/widgets/user_profile_mutual_list.dart
+++ b/lib/features/profile/presentation/widgets/user_profile_mutual_list.dart
@@ -3,10 +3,13 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:fluxer_app/core/database/fluxer_database.dart' as db;
 import 'package:fluxer_app/core/media/fluxer_media_url.dart';
 import 'package:fluxer_app/core/theme/fluxer_theme_extension.dart';
+import 'package:fluxer_app/features/friends/domain/friend.dart';
+import 'package:fluxer_app/features/friends/providers/friend_providers.dart';
 import 'package:fluxer_app/features/guilds/domain/guild.dart';
 import 'package:fluxer_app/features/profile/providers/user_profile_guild_provider.dart';
 import 'package:fluxer_app/features/ui/ui.dart';
 import 'package:fluxer_app/l10n/generated/fluxer_localizations.dart';
+import 'package:fluxer_app/shared/utils/display_name.dart';
 import 'package:fluxer_dart/export.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
 
@@ -43,14 +46,14 @@ class UserProfileMutualList extends ConsumerWidget {
   }
 }
 
-class _MutualFriendList extends StatelessWidget {
+class _MutualFriendList extends ConsumerWidget {
   const _MutualFriendList({required this.friends, required this.onFriendTap});
 
   final List<UserPartialResponse> friends;
   final ValueChanged<UserPartialResponse> onFriendTap;
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final FluxerLocalizations l10n = FluxerLocalizations.of(context);
     if (friends.isEmpty) {
       return _MutualEmptyState(
@@ -58,22 +61,30 @@ class _MutualFriendList extends StatelessWidget {
         label: l10n.userProfileNoMutualFriends,
       );
     }
+    final Map<String, String?> friendNicknameById = friendNicknamesById(
+      ref.watch(friendsListProvider).value ?? const <Friend>[],
+    );
     return FluxerListSection(
       dividers: false,
       children: friends
           .map((UserPartialResponse friend) {
+            final String displayName = resolveDisplayName(
+              friendNickname: friendNicknameById[friend.id],
+              globalName: friend.globalName,
+              username: friend.username,
+            );
             return FluxerListRow(
               leading: FluxerAvatar.user(
                 imageUrl: FluxerMediaUrl.userAvatar(
                   userId: friend.id,
                   hash: friend.avatar,
                 ),
-                fallbackText: friend.globalName ?? friend.username,
+                fallbackText: displayName,
                 avatarColor: friend.avatarColor,
                 userId: friend.id,
                 showStatus: false,
               ),
-              title: friend.globalName ?? friend.username,
+              title: displayName,
               subtitle: '${friend.username}#${friend.discriminator}',
               onTap: () => onFriendTap(friend),
             );

--- a/lib/features/profile/presentation/widgets/user_profile_view.dart
+++ b/lib/features/profile/presentation/widgets/user_profile_view.dart
@@ -863,7 +863,7 @@ class _UserProfileViewState extends ConsumerState<UserProfileView> {
             resolveGuildUserDisplayFromProfile(
               response: response,
               guildId: guildId,
-              relationshipNickname: relationshipAsync.value?.nickname,
+              friendNickname: relationshipAsync.value?.nickname,
               showGlobalProfile: _showGlobalProfile,
             );
         return _buildLoadedView(

--- a/lib/features/quick_switcher/data/quick_switcher_candidate_builder.dart
+++ b/lib/features/quick_switcher/data/quick_switcher_candidate_builder.dart
@@ -7,6 +7,7 @@ import 'package:fluxer_app/features/quick_switcher/domain/quick_switcher_build_i
 import 'package:fluxer_app/features/quick_switcher/domain/quick_switcher_candidate.dart';
 import 'package:fluxer_app/features/quick_switcher/domain/quick_switcher_types.dart';
 import 'package:fluxer_app/l10n/generated/fluxer_localizations.dart';
+import 'package:fluxer_app/shared/utils/display_name.dart';
 import 'package:fluxer_app/shared/utils/snowflake_time.dart';
 
 QuickSwitcherCandidateSets buildQuickSwitcherCandidateSets(
@@ -15,6 +16,9 @@ QuickSwitcherCandidateSets buildQuickSwitcherCandidateSets(
   final Map<String, Guild> guildsById = <String, Guild>{
     for (final Guild guild in input.guilds) guild.id: guild,
   };
+  final Map<String, String?> friendNicknameById = friendNicknamesById(
+    input.friends,
+  );
   final Map<String, QuickSwitcherUserCandidate> users =
       <String, QuickSwitcherUserCandidate>{};
   final List<QuickSwitcherGroupDmCandidate> groupDms =
@@ -31,15 +35,19 @@ QuickSwitcherCandidateSets buildQuickSwitcherCandidateSets(
     if (convo.isPersonalNotes) {
       continue;
     }
+    final String resolvedName = convo.displayNameWith(
+      friendNicknameById[convo.recipientId],
+    );
     final QuickSwitcherUserCandidate userCandidate = QuickSwitcherUserCandidate(
       id: convo.recipientId,
-      title: convo.displayName,
+      title: resolvedName,
       subtitle: convo.recipientUsername ?? convo.recipientName,
       userId: convo.recipientId,
       dmChannelId: convo.id,
       avatar: convo.recipientAvatar,
       status: convo.recipientStatus,
       searchValues: <String>[
+        resolvedName,
         convo.displayName,
         convo.recipientName,
         if (convo.recipientUsername != null) convo.recipientUsername!,
@@ -65,18 +73,24 @@ QuickSwitcherCandidateSets buildQuickSwitcherCandidateSets(
     if (member.id == input.currentUserId) {
       continue;
     }
+    final String memberName = resolveDisplayName(
+      guildNickname: member.nickname,
+      friendNickname: friendNicknameById[member.id],
+      globalName: member.globalName,
+      username: member.username,
+    );
     users.putIfAbsent(
       member.id,
       () => QuickSwitcherUserCandidate(
         id: member.id,
-        title: member.nickname ?? member.globalName ?? member.username,
+        title: memberName,
         subtitle: member.username,
         userId: member.id,
         avatar: member.avatar,
         avatarColor: member.avatarColor,
         status: member.status,
         searchValues: <String>[
-          member.nickname ?? member.globalName ?? member.username,
+          memberName,
           member.username,
           if (member.globalName != null) member.globalName!,
           member.id,
@@ -222,6 +236,7 @@ List<QuickSwitcherUserCandidate> mergeMemberSearchCandidates({
   required List<QuickSwitcherUserCandidate> baseCandidates,
   required List<Member> memberSearchResults,
   required String? currentUserId,
+  Map<String, String?> friendNicknameById = const <String, String?>{},
 }) {
   if (memberSearchResults.isEmpty) {
     return baseCandidates;
@@ -235,18 +250,24 @@ List<QuickSwitcherUserCandidate> mergeMemberSearchCandidates({
     if (member.id == currentUserId) {
       continue;
     }
+    final String memberName = resolveDisplayName(
+      guildNickname: member.nickname,
+      friendNickname: friendNicknameById[member.id],
+      globalName: member.globalName,
+      username: member.username,
+    );
     candidateMap.putIfAbsent(
       member.id,
       () => QuickSwitcherUserCandidate(
         id: member.id,
-        title: member.nickname ?? member.globalName ?? member.username,
+        title: memberName,
         subtitle: member.username,
         userId: member.id,
         avatar: member.avatar,
         avatarColor: member.avatarColor,
         status: member.status,
         searchValues: <String>[
-          member.nickname ?? member.globalName ?? member.username,
+          memberName,
           member.username,
           if (member.globalName != null) member.globalName!,
           member.id,

--- a/lib/features/quick_switcher/data/quick_switcher_result_generators.dart
+++ b/lib/features/quick_switcher/data/quick_switcher_result_generators.dart
@@ -84,6 +84,7 @@ List<QuickSwitcherResult> generateQuickSwitcherQueryModeResults({
   required List<Member> memberSearchResults,
   required String? currentUserId,
   required Set<String> excludedChannelIds,
+  Map<String, String?> friendNicknameById = const <String, String?>{},
 }) {
   List<QuickSwitcherCandidate> candidates;
   switch (queryMode) {
@@ -92,6 +93,7 @@ List<QuickSwitcherResult> generateQuickSwitcherQueryModeResults({
         baseCandidates: sets.users,
         memberSearchResults: memberSearchResults,
         currentUserId: currentUserId,
+        friendNicknameById: friendNicknameById,
       );
     case QuickSwitcherQueryMode.textChannel:
       candidates = sets.textChannels;

--- a/lib/features/quick_switcher/providers/quick_switcher_provider.dart
+++ b/lib/features/quick_switcher/providers/quick_switcher_provider.dart
@@ -7,6 +7,7 @@ import 'package:fluxer_app/features/channels/domain/channel.dart';
 import 'package:fluxer_app/features/dm/domain/dm_conversation.dart';
 import 'package:fluxer_app/features/dm/providers/dm_view_model.dart';
 import 'package:fluxer_app/features/favorites/providers/favorite_channels_provider.dart';
+import 'package:fluxer_app/features/friends/domain/friend.dart';
 import 'package:fluxer_app/features/guilds/domain/guild.dart';
 import 'package:fluxer_app/features/guilds/providers/guild_list_view_model.dart';
 import 'package:fluxer_app/features/members/domain/member.dart';
@@ -295,6 +296,9 @@ class QuickSwitcher extends _$QuickSwitcher {
         memberSearchResults: _memberSearchResults,
         currentUserId: ref.read(currentUserIdProvider),
         excludedChannelIds: excludedChannelIds,
+        friendNicknameById: friendNicknamesById(
+          ref.read(dmViewModelProvider).friendsList,
+        ),
       );
     } else {
       results = generateQuickSwitcherGeneralResults(

--- a/lib/features/settings/data/guild_audit_log_member_repository.dart
+++ b/lib/features/settings/data/guild_audit_log_member_repository.dart
@@ -133,6 +133,9 @@ class GuildAuditLogMemberRepository {
     required String guildId,
     required Set<String> userIds,
   }) async {
+    final Map<String, String?> nicknameByUserId = await _database
+        .relationshipDao
+        .getNicknamesByUserId();
     final Map<String, GuildUserDisplay> displays = <String, GuildUserDisplay>{};
     for (final String userId in userIds) {
       final db.User? user = await _database.userDao.getUserById(userId);
@@ -147,6 +150,7 @@ class GuildAuditLogMemberRepository {
         user: user,
         member: member,
         guildId: guildId,
+        friendNickname: nicknameByUserId[userId],
       );
     }
     return displays;

--- a/lib/features/ui/voice/voice_channel_participant_grid.dart
+++ b/lib/features/ui/voice/voice_channel_participant_grid.dart
@@ -20,6 +20,8 @@ import 'package:fluxer_app/features/voice/providers/voice_session_state.dart';
 import 'package:fluxer_app/features/voice/utils/voice_grid_layout/voice_grid_layout.dart';
 import 'package:fluxer_app/features/voice/utils/voice_participant_track_resolver.dart';
 import 'package:fluxer_app/l10n/generated/fluxer_localizations.dart';
+import 'package:fluxer_app/shared/providers/guild_user_display_provider.dart';
+import 'package:fluxer_app/shared/utils/guild_user_display.dart';
 import 'package:fluxer_dart/gateway.dart';
 import 'package:livekit_client/livekit_client.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
@@ -690,6 +692,7 @@ class _VoiceChannelParticipantGridState
         );
     return _VoiceParticipantCard(
       data: tile.data,
+      guildId: widget.guildId,
       room: room,
       currentUserId: me,
       localConnectionId: localConnectionId,
@@ -745,9 +748,10 @@ class _TileEnterAnimation extends StatelessWidget {
   }
 }
 
-class _VoiceParticipantCard extends StatelessWidget {
+class _VoiceParticipantCard extends ConsumerWidget {
   const _VoiceParticipantCard({
     required this.data,
+    required this.guildId,
     required this.room,
     required this.currentUserId,
     required this.localConnectionId,
@@ -764,6 +768,7 @@ class _VoiceParticipantCard extends StatelessWidget {
   });
 
   final VoiceChannelParticipantData data;
+  final String? guildId;
   final Room? room;
   final String? currentUserId;
   final String? localConnectionId;
@@ -779,11 +784,14 @@ class _VoiceParticipantCard extends StatelessWidget {
   final FluxerLocalizations l10n;
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final database.User? user = data.user;
-    final String display = user != null
-        ? (user.globalName ?? user.username)
-        : data.userId;
+    final GuildUserDisplay? resolvedDisplay = ref
+        .watch(guildUserDisplayFromDbProvider((data.userId, guildId)))
+        .value;
+    final String display =
+        resolvedDisplay?.displayName ??
+        (user != null ? (user.globalName ?? user.username) : data.userId);
     final VoiceState v = data.voice;
     final int? avatarArgb = user?.avatarColor;
     final Color cardColor = avatarArgb == null

--- a/lib/features/voice/providers/voice_channel_participants_provider.dart
+++ b/lib/features/voice/providers/voice_channel_participants_provider.dart
@@ -1,6 +1,7 @@
 import 'package:fluxer_app/core/database/fluxer_database.dart' as database;
 import 'package:fluxer_app/core/providers/database_provider.dart';
 import 'package:fluxer_app/features/gateway/providers/gateway_event_providers.dart';
+import 'package:fluxer_app/shared/utils/display_name.dart';
 import 'package:fluxer_app/shared/utils/guild_user_display.dart';
 import 'package:fluxer_dart/gateway.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
@@ -79,21 +80,30 @@ class VoiceSidebarParticipant {
   final bool guildDeaf;
 }
 
-String _displayNameForSort(String userId, Map<String, database.User> byId) {
+String _displayNameForSort(
+  String userId,
+  Map<String, database.User> byId,
+  Map<String, String?> nicknameByUserId,
+) {
   final database.User? u = byId[userId];
   if (u == null) {
     return userId;
   }
-  return u.globalName ?? u.username;
+  return resolveDisplayName(
+    friendNickname: nicknameByUserId[userId],
+    globalName: u.globalName,
+    username: u.username,
+  );
 }
 
 int _compareVoiceStateForSort(
   VoiceState a,
   VoiceState b,
   Map<String, database.User> byId,
+  Map<String, String?> nicknameByUserId,
 ) {
-  final String nameA = _displayNameForSort(a.userId, byId);
-  final String nameB = _displayNameForSort(b.userId, byId);
+  final String nameA = _displayNameForSort(a.userId, byId, nicknameByUserId);
+  final String nameB = _displayNameForSort(b.userId, byId, nicknameByUserId);
   final int byName = nameA.toLowerCase().compareTo(nameB.toLowerCase());
   if (byName != 0) {
     return byName;
@@ -131,9 +141,14 @@ Future<List<VoiceChannelParticipantData>> voiceChannelParticipants(
     ref,
     userIds,
   );
+  final Map<String, String?> nicknameByUserId = await ref
+      .read(fluxerDatabaseProvider)
+      .relationshipDao
+      .getNicknamesByUserId();
   final List<VoiceState> sortedInChannel = List<VoiceState>.of(inChannel)
     ..sort(
-      (VoiceState a, VoiceState b) => _compareVoiceStateForSort(a, b, byId),
+      (VoiceState a, VoiceState b) =>
+          _compareVoiceStateForSort(a, b, byId, nicknameByUserId),
     );
   return sortedInChannel
       .map(
@@ -199,6 +214,8 @@ Future<List<VoiceSidebarParticipant>> voiceChannelSidebarParticipants(
       <String, database.Member>{
         for (final database.Member m in memberRows) m.userId: m,
       };
+  final Map<String, String?> nicknameByUserId = await db.relationshipDao
+      .getNicknamesByUserId();
   final List<VoiceSidebarParticipant> out = <VoiceSidebarParticipant>[];
   for (final String userId in userIds) {
     final database.User? user = usersById[userId];
@@ -211,6 +228,7 @@ Future<List<VoiceSidebarParticipant>> voiceChannelSidebarParticipants(
       user: user,
       member: member,
       guildId: guildId,
+      friendNickname: nicknameByUserId[userId],
     );
     out.add(
       VoiceSidebarParticipant(

--- a/lib/shared/providers/guild_user_display_provider.dart
+++ b/lib/shared/providers/guild_user_display_provider.dart
@@ -9,6 +9,7 @@ import 'package:fluxer_app/core/providers/database_provider.dart';
 import 'package:fluxer_app/core/router/route_state_providers.dart';
 import 'package:fluxer_app/features/channels/providers/channel_providers.dart';
 import 'package:fluxer_app/features/chat/domain/message.dart';
+import 'package:fluxer_app/features/friends/providers/friend_providers.dart';
 import 'package:fluxer_app/shared/providers/member_role_color.dart';
 import 'package:fluxer_app/shared/utils/guild_user_display.dart';
 import 'package:fluxer_app/shared/utils/mention_display_utils.dart';
@@ -138,6 +139,9 @@ AsyncValue<GuildUserDisplay?> _combine(
       guildId != null && guildId.isNotEmpty
       ? ref.watch(_memberRowProvider((userId, guildId)))
       : const AsyncValue<db.Member?>.data(null);
+  final String? friendNickname = ref
+      .watch(friendNicknameProvider(userId))
+      .value;
   if (fetchOnMiss &&
       guildId != null &&
       guildId.isNotEmpty &&
@@ -166,6 +170,7 @@ AsyncValue<GuildUserDisplay?> _combine(
             user: user,
             member: memberAsync.value,
             guildId: guildId,
+            friendNickname: friendNickname,
           ),
   );
 }

--- a/lib/shared/utils/display_name.dart
+++ b/lib/shared/utils/display_name.dart
@@ -1,0 +1,20 @@
+String resolveDisplayName({
+  required String username,
+  String? guildNickname,
+  String? friendNickname,
+  String? fallbackDisplayName,
+  String? globalName,
+}) {
+  for (final String? candidate in <String?>[
+    guildNickname,
+    friendNickname,
+    fallbackDisplayName,
+    globalName,
+  ]) {
+    final String? trimmed = candidate?.trim();
+    if (trimmed != null && trimmed.isNotEmpty) {
+      return trimmed;
+    }
+  }
+  return username;
+}

--- a/lib/shared/utils/guild_member_prefetch.dart
+++ b/lib/shared/utils/guild_member_prefetch.dart
@@ -121,6 +121,8 @@ Future<Map<String, GuildUserDisplay>> resolveGuildUserDisplaysForUserIds({
     userIds: uniqueUserIds,
     onMemberFetched: onMemberFetched,
   );
+  final Map<String, String?> nicknameByUserId = await database.relationshipDao
+      .getNicknamesByUserId();
   final Map<String, GuildUserDisplay> displays = <String, GuildUserDisplay>{};
   for (final String userId in uniqueUserIds) {
     final db.User? user = await database.userDao.getUserById(userId);
@@ -135,6 +137,7 @@ Future<Map<String, GuildUserDisplay>> resolveGuildUserDisplaysForUserIds({
       user: user,
       member: member,
       guildId: guildId,
+      friendNickname: nicknameByUserId[userId],
     );
   }
   return displays;

--- a/lib/shared/utils/guild_user_display.dart
+++ b/lib/shared/utils/guild_user_display.dart
@@ -4,6 +4,7 @@ import 'package:fluxer_app/core/database/fluxer_database.dart' as db;
 import 'package:fluxer_app/core/media/fluxer_media_hash.dart';
 import 'package:fluxer_app/core/media/fluxer_media_url.dart';
 import 'package:fluxer_app/features/chat/domain/message.dart';
+import 'package:fluxer_app/shared/utils/display_name.dart';
 import 'package:fluxer_dart/export.dart';
 
 const int guildProfileDefaultAccentColor = 0x4641D9;
@@ -93,11 +94,7 @@ String resolveAccountDisplayName({
   required String username,
   String? globalName,
 }) {
-  final String? trimmedGlobalName = globalName?.trim();
-  if (trimmedGlobalName != null && trimmedGlobalName.isNotEmpty) {
-    return trimmedGlobalName;
-  }
-  return username;
+  return resolveDisplayName(username: username, globalName: globalName);
 }
 
 String resolveMessageAuthorName(UserPartialResponse author) {
@@ -118,14 +115,18 @@ GuildUserDisplay resolveGuildUserDisplayFromRows({
   required db.User user,
   required db.Member? member,
   required String? guildId,
+  String? friendNickname,
   String? fallbackDisplayName,
   String? fallbackAvatarHash,
   int? fallbackAvatarColor,
 }) {
-  final String? nick = member?.nick?.trim();
-  final String displayName = nick != null && nick.isNotEmpty
-      ? nick
-      : fallbackDisplayName ?? user.globalName ?? user.username;
+  final String displayName = resolveDisplayName(
+    guildNickname: member?.nick,
+    friendNickname: friendNickname,
+    fallbackDisplayName: fallbackDisplayName,
+    globalName: user.globalName,
+    username: user.username,
+  );
   final String? memberAvatar = member?.serverAvatar;
   final bool isAvatarUnset =
       guildId != null &&
@@ -169,10 +170,10 @@ GuildUserDisplay resolveGuildUserDisplayFromMessage({
   required String? guildId,
   bool animatedAvatar = true,
 }) {
-  final String? nick = member?.nick?.trim();
-  final String displayName = nick != null && nick.isNotEmpty
-      ? nick
-      : fallbackDisplayName;
+  final String displayName = resolveDisplayName(
+    guildNickname: member?.nick,
+    username: fallbackDisplayName,
+  );
   final String? memberAvatar = member?.serverAvatar;
   final bool isAvatarUnset =
       guildId != null &&
@@ -272,7 +273,7 @@ GuildUserDisplay resolveMessageAuthorDisplay({
 GuildUserDisplay resolveGuildUserDisplayFromProfile({
   required UserProfileFullResponse response,
   required String? guildId,
-  required String? relationshipNickname,
+  required String? friendNickname,
   bool showGlobalProfile = false,
 }) {
   final UserProfileFullResponseUser user = response.user;
@@ -331,7 +332,7 @@ GuildUserDisplay resolveGuildUserDisplayFromProfile({
     displayName: resolveGuildProfileDisplayName(
       user: user,
       guildMember: guildMember,
-      relationshipNickname: relationshipNickname,
+      friendNickname: friendNickname,
       useGuildProfile: canUseGuildProfile,
     ),
     accountDisplayName: resolveAccountDisplayName(
@@ -365,18 +366,13 @@ bool hasMemberProfileFlag(int? profileFlags, int flag) {
 String resolveGuildProfileDisplayName({
   required UserProfileFullResponseUser user,
   required GuildMemberResponse? guildMember,
-  required String? relationshipNickname,
+  required String? friendNickname,
   required bool useGuildProfile,
 }) {
-  final String? nickname = relationshipNickname?.trim();
-  if (nickname != null && nickname.isNotEmpty) {
-    return nickname;
-  }
-  final String? guildNickname = useGuildProfile
-      ? guildMember?.nick?.trim()
-      : null;
-  if (guildNickname != null && guildNickname.isNotEmpty) {
-    return guildNickname;
-  }
-  return user.globalName ?? user.username;
+  return resolveDisplayName(
+    guildNickname: useGuildProfile ? guildMember?.nick : null,
+    friendNickname: friendNickname,
+    globalName: user.globalName,
+    username: user.username,
+  );
 }

--- a/test/features/dm/domain/dm_conversation_test.dart
+++ b/test/features/dm/domain/dm_conversation_test.dart
@@ -1,0 +1,38 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fluxer_app/features/dm/domain/dm_conversation.dart';
+
+void main() {
+  DmConversation convo({required int type}) {
+    return DmConversation(
+      id: '1',
+      type: type,
+      recipientId: '2',
+      recipientName: 'Global Name',
+      name: type == 3 ? 'Group' : null,
+      lastMessage: '',
+      lastMessageTime: DateTime(2020),
+    );
+  }
+
+  group('DmConversation.displayNameWith', () {
+    test('uses the friend nickname for a direct message channel', () {
+      expect(convo(type: 0).displayNameWith('Nick'), 'Nick');
+    });
+
+    test('falls back to the recipient name when the nickname is blank', () {
+      expect(convo(type: 0).displayNameWith('   '), 'Global Name');
+      expect(convo(type: 0).displayNameWith(null), 'Global Name');
+    });
+
+    test(
+      'does not expose the friend nickname for a group direct message channel',
+      () {
+        expect(convo(type: 3).displayNameWith('Nick'), 'Group');
+      },
+    );
+
+    test('does not expose the friend nickname for personal notes', () {
+      expect(convo(type: 999).displayNameWith('Nick'), 'Personal Notes');
+    });
+  });
+}

--- a/test/shared/utils/guild_user_display_test.dart
+++ b/test/shared/utils/guild_user_display_test.dart
@@ -5,17 +5,56 @@ import 'package:fluxer_app/core/database/fluxer_database.dart' as db;
 import 'package:fluxer_app/core/media/fluxer_media_url.dart';
 import 'package:fluxer_app/features/chat/domain/message.dart';
 import 'package:fluxer_app/features/members/domain/member.dart' as members;
+import 'package:fluxer_app/shared/utils/display_name.dart';
 import 'package:fluxer_app/shared/utils/guild_user_display.dart';
 import 'package:fluxer_app/shared/utils/mention_display_utils.dart';
 import 'package:fluxer_dart/export.dart';
 
 void main() {
+  group('resolveDisplayName', () {
+    test('prefers guild > friend > global > username', () {
+      expect(
+        resolveDisplayName(
+          username: 'user',
+          guildNickname: 'Guild',
+          friendNickname: 'Friend',
+          globalName: 'Global',
+        ),
+        'Guild',
+      );
+      expect(
+        resolveDisplayName(
+          username: 'user',
+          friendNickname: 'Friend',
+          globalName: 'Global',
+        ),
+        'Friend',
+      );
+      expect(
+        resolveDisplayName(username: 'user', globalName: 'Global'),
+        'Global',
+      );
+      expect(resolveDisplayName(username: 'user'), 'user');
+    });
+
+    test('skips blank', () {
+      expect(
+        resolveDisplayName(
+          username: 'user',
+          guildNickname: '   ',
+          friendNickname: 'Friend',
+        ),
+        'Friend',
+      );
+    });
+  });
+
   group('resolveGuildUserDisplayFromProfile', () {
     test('uses global profile when guild data is absent', () {
       final GuildUserDisplay actual = resolveGuildUserDisplayFromProfile(
         response: _profile(userPronouns: 'they/them'),
         guildId: null,
-        relationshipNickname: null,
+        friendNickname: null,
       );
       expect(actual.displayName, 'Global Name');
       expect(actual.avatarUrl, contains('/avatars/1/user_avatar.webp'));
@@ -36,7 +75,7 @@ void main() {
           ),
         ),
         guildId: '10',
-        relationshipNickname: null,
+        friendNickname: null,
       );
       expect(actual.displayName, 'Guild Nick');
       expect(
@@ -55,7 +94,7 @@ void main() {
       final GuildUserDisplay actual = resolveGuildUserDisplayFromProfile(
         response: _profile(userAvatar: 'a_user_avatar', userBanner: 'a_banner'),
         guildId: null,
-        relationshipNickname: null,
+        friendNickname: null,
       );
       expect(actual.avatarUrl, contains('/avatars/1/user_avatar.webp?size='));
       expect(
@@ -71,7 +110,7 @@ void main() {
           guildProfile: _guildProfile(banner: 'a_guild_banner'),
         ),
         guildId: '10',
-        relationshipNickname: null,
+        friendNickname: null,
       );
       expect(
         actual.avatarUrl,
@@ -83,13 +122,13 @@ void main() {
       );
     });
 
-    test('relationship nickname overrides guild nickname', () {
+    test('guild nickname overrides friend nickname', () {
       final GuildUserDisplay actual = resolveGuildUserDisplayFromProfile(
         response: _profile(guildMember: _guildMember(nick: 'Guild Nick')),
         guildId: '10',
-        relationshipNickname: 'Friend Nick',
+        friendNickname: 'Friend Nick',
       );
-      expect(actual.displayName, 'Friend Nick');
+      expect(actual.displayName, 'Guild Nick');
     });
 
     test('avatar unset forces default avatar fallback', () {
@@ -101,7 +140,7 @@ void main() {
           ),
         ),
         guildId: '10',
-        relationshipNickname: null,
+        friendNickname: null,
       );
       expect(actual.avatarUrl, isNull);
     });
@@ -113,7 +152,7 @@ void main() {
           guildProfile: _guildProfile(banner: 'guild_banner'),
         ),
         guildId: '10',
-        relationshipNickname: null,
+        friendNickname: null,
       );
       expect(actual.bannerUrl, isNull);
       expect(actual.bannerColor, const Color(0xFF112233));
@@ -123,7 +162,7 @@ void main() {
       final GuildUserDisplay actual = resolveGuildUserDisplayFromProfile(
         response: _profile(guildProfile: _guildProfile()),
         guildId: '10',
-        relationshipNickname: null,
+        friendNickname: null,
       );
       expect(actual.bio, 'global bio');
     });
@@ -136,7 +175,7 @@ void main() {
           guildProfile: _guildProfile(),
         ),
         guildId: '10',
-        relationshipNickname: null,
+        friendNickname: null,
       );
       expect(actual.pronouns, 'she/her');
     });
@@ -149,7 +188,7 @@ void main() {
           guildProfile: _guildProfile(pronouns: 'he/him'),
         ),
         guildId: '10',
-        relationshipNickname: null,
+        friendNickname: null,
         showGlobalProfile: true,
       );
       expect(actual.pronouns, 'they/them');


### PR DESCRIPTION
Friend nicknames are now exposed everywhere instead of only in select places.

Additionally, the friend nickname presentation now exists instead of the button to modify a friend nickname being a no-op.

Matches desktop logic to decide when to show a friend nickname.

Resolves #435.
