### PR TITLE
fix(fluxer_captcha): ignore name resolution errors for captchas

### DIFF
--- a/packages/fluxer_captcha/lib/src/widget/impl/captcha_widget_native.dart
+++ b/packages/fluxer_captcha/lib/src/widget/impl/captcha_widget_native.dart
@@ -292,7 +292,7 @@ String buildHTML({
   };
 }
 
-final _ignoredWebResourceErrorTypes = [
+final List<WebResourceErrorType> _ignoredWebResourceErrorTypes = [
   // I don't know why this needs to be ignored specifically as it wasn't added by me, but maybe someone can replace this comment with an explanation.
   WebResourceErrorType.CANNOT_CONNECT_TO_HOST,
   // This needs to be ignored for Turnstile to function on IPv4-only networks.

--- a/packages/fluxer_captcha/lib/src/widget/impl/captcha_widget_native.dart
+++ b/packages/fluxer_captcha/lib/src/widget/impl/captcha_widget_native.dart
@@ -292,6 +292,21 @@ String buildHTML({
   };
 }
 
+final _ignoredWebResourceErrorTypes = [
+  // I don't know why this needs to be ignored specifically as it wasn't added by me, but maybe someone can replace this comment with an explanation.
+  WebResourceErrorType.CANNOT_CONNECT_TO_HOST,
+  // This needs to be ignored for Turnstile to function on IPv4-only networks.
+  // See this forum post: https://community.cloudflare.com/t/turnstile-net-err-name-not-resolved-error-in-console-on-brunhild-challenges/937102/8
+  // TL;DR: Turnstile looks up a domain that is intentionally IPv6-only, but
+  // will gracefully continue working with IPv4, so it is considered a bug to
+  // interpret the name resolution failure as fatal.
+  WebResourceErrorType.HOST_LOOKUP,
+];
+
+bool _shouldIgnoreWebResourceError(WebResourceError error) {
+  return _ignoredWebResourceErrorTypes.contains(error.type);
+}
+
 /// FluxerCaptcha for native (mobile/desktop) platforms.
 class FluxerCaptcha extends StatefulWidget implements i.FluxerCaptcha {
   FluxerCaptcha({
@@ -682,7 +697,7 @@ class _FluxerCaptchaState extends State<FluxerCaptcha> {
     },
     onConsoleMessage: (controller, consoleMessage) {},
     onReceivedError: (controller, _, error) {
-      if (error.type == WebResourceErrorType.CANNOT_CONNECT_TO_HOST) {
+      if (_shouldIgnoreWebResourceError(error)) {
         return;
       }
       _ready(false);
@@ -807,7 +822,7 @@ class _CaptchaInvisible extends FluxerCaptcha {
       },
       onConsoleMessage: (_, _) {},
       onReceivedError: (_, _, error) {
-        if (error.type == WebResourceErrorType.CANNOT_CONNECT_TO_HOST) {
+        if (_shouldIgnoreWebResourceError(error)) {
           return;
         }
         controller?.error = CaptchaException(error.description);


### PR DESCRIPTION
# What this PR solves/adds

When using Cloudflare Turnstile on an IPv4-only network, it's normal for a name resolution to failure to occur as Turnstile will try to resolve a domain that is IPv6-only, but then will usually gracefully continue working if name resolution fails. Currently, fluxer_captcha will abort the captcha submission on most errors, including on name resolution errors.

This change simply adds name resolution errors as another error which is ignored rather than aborting the captcha submission, which is suggested as the correct way to handle that error by a Cloudflare Team member on [this forum post](https://community.cloudflare.com/t/turnstile-net-err-name-not-resolved-error-in-console-on-brunhild-challenges/937102/8).

The current behaviour is that Turnstile eternally fails with net::ERR_NAME_NOT_RESOLVED in a loop if your network doesn't support IPv6. With this change, it's now possible to pass Turnstile captchas on IPv4-only networks.

<details>
<summary>Evidence</summary>
<img width="1080" height="922" alt="image" src="https://github.com/user-attachments/assets/ca19ad8e-be79-4692-9ad2-8dec4be6acdb" />

</details>

## PR type

- [ ] Feature
- [x] Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Feature requirements

- GitHub Discussion link: N/A
- Visual proof (screenshot or video): N/A

## Validation

- [x] I explained what this PR solves or adds.
- [x] I verified the changes locally.
- [x] I completed all required feature items, or marked them as `N/A` if not applicable.
- [x] All my commits are signed off under the DCO (`git commit -s`).